### PR TITLE
Add extensive integration tests to almost all repository classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,16 @@ The codebase also includes a comprehensive list of entries in the database.
 - doobie
 - circe
 - flyway
+- testcontainers
 
 ## Requirements (at the moment)
-- sbt 1.9.9
-- JDK 21
+- sbt 1.8.3
+- JDK 17
 - PostgreSQL 16
 
 ## Future plans
+- Codebase for a visualization frontend using ScalaJS
 - Include a Kafka-based queue of current flight status
 - An FS2/Kafka-Streams based analysis of flight status
   - with stateful operations
   - and persistence for safe recovery upon failure
-- Codebase for a visualization frontend

--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,8 @@ val otherDependencies = Seq(
   "com.typesafe.scala-logging" %% "scala-logging"             % "3.9.5",
   "commons-io"                 % "commons-io"                 % "2.16.1",
   "org.flywaydb"               % "flyway-core"                % flywayVersion,
-  "org.flywaydb"               % "flyway-database-postgresql" % flywayVersion
+  "org.flywaydb"               % "flyway-database-postgresql" % flywayVersion,
+  "com.ibm.icu"                % "icu4j"                      % "75.1"
 )
 
 val testingDependencies = Seq(

--- a/src/it/scala/flightdatabase/repository/AirplaneRepositoryIT.scala
+++ b/src/it/scala/flightdatabase/repository/AirplaneRepositoryIT.scala
@@ -3,54 +3,199 @@ package flightdatabase.repository
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import flightdatabase.domain.ApiResult
+import flightdatabase.domain.EntryAlreadyExists
+import flightdatabase.domain.EntryCheckFailed
+import flightdatabase.domain.EntryHasInvalidForeignKey
+import flightdatabase.domain.EntryListEmpty
 import flightdatabase.domain.EntryNotFound
 import flightdatabase.domain.airplane.Airplane
+import flightdatabase.domain.airplane.AirplaneCreate
+import flightdatabase.domain.airplane.AirplanePatch
 import flightdatabase.testutils.RepositoryCheck
 
 final class AirplaneRepositoryIT extends RepositoryCheck {
 
   lazy val repo: AirplaneRepository[IO] = AirplaneRepository.make[IO].unsafeRunSync()
 
-  val expectedAirplanes: List[Airplane] = List(
+  val originalExpectedAirplanes: List[Airplane] = List(
     Airplane(1, "A380", 1, 853, 14800),
     Airplane(2, "747-8", 2, 410, 14310),
     Airplane(3, "A320neo", 1, 194, 6300),
     Airplane(4, "787-8", 2, 248, 13530)
   )
   val idNotPresent: Long = 10
-  val idDefinitelyNotPresent: Long = 1039495454540034858L
+  val veryLongIdNotPresent: Long = 1039495454540034858L
+
+  val newAirplane: AirplaneCreate = AirplaneCreate("A350", 1, 325, 13900)
 
   "Checking if an airplane exists" should "return a valid result" in {
     def airplaneExists(id: Long): Boolean =
       repo.doesAirplaneExist(id).unsafeRunSync()
     airplaneExists(1) shouldBe true
     airplaneExists(idNotPresent) shouldBe false
-    airplaneExists(idDefinitelyNotPresent) shouldBe false
+    airplaneExists(veryLongIdNotPresent) shouldBe false
   }
 
   "Selecting all airplanes" should "return the correct detailed list" in {
     val airplanes = repo.getAirplanes.unsafeRunSync().value.value
 
     airplanes should not be empty
-    airplanes should contain only (expectedAirplanes: _*)
+    airplanes should contain only (originalExpectedAirplanes: _*)
   }
 
   it should "return only names if so required" in {
     val airplanesOnlyNames = repo.getAirplanesOnlyNames.unsafeRunSync().value.value
     airplanesOnlyNames should not be empty
-    airplanesOnlyNames should contain only (expectedAirplanes.map(_.name): _*)
+    airplanesOnlyNames should contain only (originalExpectedAirplanes.map(_.name): _*)
   }
 
   "Selecting an airplane by id" should "return the correct entry" in {
     def airplaneById(id: Long): ApiResult[Airplane] = repo.getAirplane(id).unsafeRunSync()
 
-    expectedAirplanes.foreach { airplane =>
+    originalExpectedAirplanes.foreach { airplane =>
       airplaneById(airplane.id).value.value shouldBe airplane
     }
-    airplaneById(idNotPresent).left.value shouldBe EntryNotFound(idNotPresent.toString)
-    airplaneById(idDefinitelyNotPresent).left.value shouldBe EntryNotFound(
-      idDefinitelyNotPresent.toString
+    airplaneById(idNotPresent).left.value shouldBe EntryNotFound(idNotPresent)
+    airplaneById(veryLongIdNotPresent).left.value shouldBe EntryNotFound(veryLongIdNotPresent)
+  }
+
+  "Selecting an airplane by other fields" should "return the corresponding entries" in {
+    def airplaneByName(name: String): ApiResult[List[Airplane]] =
+      repo.getAirplanes("name", name).unsafeRunSync()
+    def airplaneByManufacturerId(id: Long): ApiResult[List[Airplane]] =
+      repo.getAirplanes("manufacturer_id", id).unsafeRunSync()
+
+    val distinctManufacturerIds = originalExpectedAirplanes.map(_.manufacturerId).distinct
+
+    originalExpectedAirplanes.foreach { airplane =>
+      airplaneByName(airplane.name).value.value should contain only airplane
+    }
+
+    distinctManufacturerIds.foreach { id =>
+      val expectedAirplanes = originalExpectedAirplanes.filter(_.manufacturerId == id)
+      airplaneByManufacturerId(id).value.value should contain only (expectedAirplanes: _*)
+    }
+
+    airplaneByName("Not present").left.value shouldBe EntryListEmpty
+    airplaneByManufacturerId(idNotPresent).left.value shouldBe EntryListEmpty
+    airplaneByManufacturerId(veryLongIdNotPresent).left.value shouldBe EntryListEmpty
+  }
+
+  "Selecting an airplane by manufacturer name" should "return the corresponding entries" in {
+    def airplaneByManufacturer(name: String): ApiResult[List[Airplane]] =
+      repo.getAirplanesByManufacturer(name).unsafeRunSync()
+
+    airplaneByManufacturer("Airbus").value.value should contain only (
+      originalExpectedAirplanes.filter(_.manufacturerId == 1): _*
     )
+    airplaneByManufacturer("Boeing").value.value should contain only (
+      originalExpectedAirplanes.filter(_.manufacturerId == 2): _*
+    )
+    airplaneByManufacturer("Not present").left.value shouldBe EntryListEmpty
+  }
+
+  "Creating an airplane" should "work and return the new ID" in {
+    val newId = repo.createAirplane(newAirplane).unsafeRunSync().value.value
+    val updatedAirplanes = repo.getAirplanes.unsafeRunSync().value.value
+
+    newId shouldBe originalExpectedAirplanes.length + 1
+    updatedAirplanes should contain(Airplane.fromCreate(newId, newAirplane))
+  }
+
+  it should "throw a conflict error if we try to create the same airplane again" in {
+    repo.createAirplane(newAirplane).unsafeRunSync().left.value shouldBe EntryAlreadyExists
+  }
+
+  it should "throw a foreign key error if the manufacturer does not exist" in {
+    val newAirplaneWithNonExistingManufacturerId =
+      newAirplane.copy(name = "Something", manufacturerId = idNotPresent)
+    repo
+      .createAirplane(newAirplaneWithNonExistingManufacturerId)
+      .unsafeRunSync()
+      .left
+      .value shouldBe EntryHasInvalidForeignKey
+  }
+
+  it should "throw a check error if we pass negative values for capacity or maxRangeInKm" in {
+    val newAirplaneWithNegativeCapacity = newAirplane.copy(capacity = -1)
+    repo
+      .createAirplane(newAirplaneWithNegativeCapacity)
+      .unsafeRunSync()
+      .left
+      .value shouldBe EntryCheckFailed
+
+    val newAirplaneWithNegativeMaxRange = newAirplane.copy(maxRangeInKm = -1)
+    repo
+      .createAirplane(newAirplaneWithNegativeMaxRange)
+      .unsafeRunSync()
+      .left
+      .value shouldBe EntryCheckFailed
+  }
+
+  "Updating an airplane" should "work and return the updated airplane ID" in {
+    val original = Airplane.fromCreate(originalExpectedAirplanes.length + 1, newAirplane)
+    val updated = original.copy(capacity = original.capacity + 100)
+    val returned = repo.updateAirplane(updated).unsafeRunSync().value.value
+    returned shouldBe updated.id
+  }
+
+  it should "also allow changing the name field" in {
+    val original = Airplane.fromCreate(originalExpectedAirplanes.length + 1, newAirplane)
+    val updated = original.copy(name = s"${original.name}_updated")
+    val returned = repo.updateAirplane(updated).unsafeRunSync().value.value
+    returned shouldBe updated.id
+  }
+
+  it should "throw an error if we update a non-existing airplane" in {
+    val updated = Airplane.fromCreate(idNotPresent, newAirplane)
+    repo.updateAirplane(updated).unsafeRunSync().left.value shouldBe EntryNotFound(idNotPresent)
+  }
+
+  it should "throw a foreign key error if the manufacturer does not exist" in {
+    val updated = Airplane.fromCreate(originalExpectedAirplanes.length + 1, newAirplane)
+    val updatedWithNonExistingManufacturerId = updated.copy(manufacturerId = idNotPresent)
+    repo
+      .updateAirplane(updatedWithNonExistingManufacturerId)
+      .unsafeRunSync()
+      .left
+      .value shouldBe EntryHasInvalidForeignKey
+  }
+
+  "Patching an airplane" should "work and return the patched airplane" in {
+    val original = Airplane.fromCreate(originalExpectedAirplanes.length + 1, newAirplane)
+    val patch = AirplanePatch(name = Some(s"${original.name}_patched"), None, None, None)
+    val patched = Airplane.fromPatch(original.id, patch, original)
+    val returned = repo.partiallyUpdateAirplane(original.id, patch).unsafeRunSync().value.value
+    returned shouldBe patched
+  }
+
+  it should "throw an error if we patch a non-existing airplane" in {
+    val patch = AirplanePatch(name = Some("Something"), None, None, None)
+    repo
+      .partiallyUpdateAirplane(idNotPresent, patch)
+      .unsafeRunSync()
+      .left
+      .value shouldBe EntryNotFound(idNotPresent)
+  }
+
+  it should "throw a foreign key error if the manufacturer does not exist" in {
+    val original = Airplane.fromCreate(originalExpectedAirplanes.length + 1, newAirplane)
+    val patch = AirplanePatch(None, manufacturerId = Some(idNotPresent), None, None)
+    repo
+      .partiallyUpdateAirplane(original.id, patch)
+      .unsafeRunSync()
+      .left
+      .value shouldBe EntryHasInvalidForeignKey
+  }
+
+  "Removing an airplane" should "work correctly" in {
+    val id = originalExpectedAirplanes.length + 1
+    repo.removeAirplane(id).unsafeRunSync().value.value shouldBe ()
+    repo.doesAirplaneExist(id).unsafeRunSync() shouldBe false
+  }
+
+  it should "throw an error if we try to remove a non-existing airplane" in {
+    repo.removeAirplane(idNotPresent).unsafeRunSync().left.value shouldBe EntryNotFound(idNotPresent)
   }
 
 }

--- a/src/it/scala/flightdatabase/repository/AirplaneRepositoryIT.scala
+++ b/src/it/scala/flightdatabase/repository/AirplaneRepositoryIT.scala
@@ -23,6 +23,7 @@ final class AirplaneRepositoryIT extends RepositoryCheck {
     Airplane(3, "A320neo", 1, 194, 6300),
     Airplane(4, "787-8", 2, 248, 13530)
   )
+  val manufacturerToIdMap: Map[String, Long] = Map("Airbus" -> 1, "Boeing" -> 2)
   val idNotPresent: Long = 10
   val veryLongIdNotPresent: Long = 1039495454540034858L
 
@@ -85,12 +86,13 @@ final class AirplaneRepositoryIT extends RepositoryCheck {
     def airplaneByManufacturer(name: String): ApiResult[List[Airplane]] =
       repo.getAirplanesByManufacturer(name).unsafeRunSync()
 
-    airplaneByManufacturer("Airbus").value.value should contain only (
-      originalExpectedAirplanes.filter(_.manufacturerId == 1): _*
-    )
-    airplaneByManufacturer("Boeing").value.value should contain only (
-      originalExpectedAirplanes.filter(_.manufacturerId == 2): _*
-    )
+    manufacturerToIdMap.foreach {
+      case (manufacturer, id) =>
+        airplaneByManufacturer(manufacturer).value.value should contain only (
+          originalExpectedAirplanes.filter(_.manufacturerId == id): _*
+        )
+    }
+
     airplaneByManufacturer("Not present").left.value shouldBe EntryListEmpty
   }
 
@@ -195,7 +197,9 @@ final class AirplaneRepositoryIT extends RepositoryCheck {
   }
 
   it should "throw an error if we try to remove a non-existing airplane" in {
-    repo.removeAirplane(idNotPresent).unsafeRunSync().left.value shouldBe EntryNotFound(idNotPresent)
+    repo.removeAirplane(idNotPresent).unsafeRunSync().left.value shouldBe EntryNotFound(
+      idNotPresent
+    )
   }
 
 }

--- a/src/it/scala/flightdatabase/repository/AirplaneRepositoryIT.scala
+++ b/src/it/scala/flightdatabase/repository/AirplaneRepositoryIT.scala
@@ -2,25 +2,54 @@ package flightdatabase.repository
 
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
+import flightdatabase.domain.ApiResult
+import flightdatabase.domain.EntryNotFound
 import flightdatabase.domain.airplane.Airplane
 import flightdatabase.testutils.RepositoryCheck
 
 final class AirplaneRepositoryIT extends RepositoryCheck {
 
+  lazy val repo: AirplaneRepository[IO] = AirplaneRepository.make[IO].unsafeRunSync()
+
+  val expectedAirplanes: List[Airplane] = List(
+    Airplane(1, "A380", 1, 853, 14800),
+    Airplane(2, "747-8", 2, 410, 14310),
+    Airplane(3, "A320neo", 1, 194, 6300),
+    Airplane(4, "787-8", 2, 248, 13530)
+  )
+  val idNotPresent: Long = 10
+  val idDefinitelyNotPresent: Long = 1039495454540034858L
+
+  "Checking if an airplane exists" should "return a valid result" in {
+    def airplaneExists(id: Long): Boolean =
+      repo.doesAirplaneExist(id).unsafeRunSync()
+    airplaneExists(1) shouldBe true
+    airplaneExists(idNotPresent) shouldBe false
+    airplaneExists(idDefinitelyNotPresent) shouldBe false
+  }
+
   "Selecting all airplanes" should "return the correct detailed list" in {
-    val airplanes = {
-      for {
-        repo         <- AirplaneRepository.make[IO]
-        allAirplanes <- repo.getAirplanes
-      } yield allAirplanes
-    }.unsafeRunSync().value.value
+    val airplanes = repo.getAirplanes.unsafeRunSync().value.value
 
     airplanes should not be empty
-    airplanes should contain only (
-      Airplane(1, "A380", 1, 853, 14800),
-      Airplane(2, "747-8", 2, 410, 14310),
-      Airplane(3, "A320neo", 1, 194, 6300),
-      Airplane(4, "787-8", 2, 248, 13530)
+    airplanes should contain only (expectedAirplanes: _*)
+  }
+
+  it should "return only names if so required" in {
+    val airplanesOnlyNames = repo.getAirplanesOnlyNames.unsafeRunSync().value.value
+    airplanesOnlyNames should not be empty
+    airplanesOnlyNames should contain only (expectedAirplanes.map(_.name): _*)
+  }
+
+  "Selecting an airplane by id" should "return the correct entry" in {
+    def airplaneById(id: Long): ApiResult[Airplane] = repo.getAirplane(id).unsafeRunSync()
+
+    expectedAirplanes.foreach { airplane =>
+      airplaneById(airplane.id).value.value shouldBe airplane
+    }
+    airplaneById(idNotPresent).left.value shouldBe EntryNotFound(idNotPresent.toString)
+    airplaneById(idDefinitelyNotPresent).left.value shouldBe EntryNotFound(
+      idDefinitelyNotPresent.toString
     )
   }
 

--- a/src/it/scala/flightdatabase/repository/AirportRepositoryIT.scala
+++ b/src/it/scala/flightdatabase/repository/AirportRepositoryIT.scala
@@ -16,7 +16,7 @@ import flightdatabase.testutils.RepositoryCheck
 import flightdatabase.utils.FieldValue
 import org.scalatest.Inspectors.forAll
 
-class AirportRepositoryIT extends RepositoryCheck {
+final class AirportRepositoryIT extends RepositoryCheck {
 
   lazy val repo: AirportRepository[IO] = AirportRepository.make[IO].unsafeRunSync()
 

--- a/src/it/scala/flightdatabase/repository/AirportRepositoryIT.scala
+++ b/src/it/scala/flightdatabase/repository/AirportRepositoryIT.scala
@@ -78,6 +78,9 @@ class AirportRepositoryIT extends RepositoryCheck {
     junction = false
   )
 
+  val updatedName: String = "Chhatrapati Shivaji Maharaj International Airport Updated"
+  val patchedName: String = "Chhatrapati Shivaji Maharaj International Airport Patched"
+
   "Checking if an airport exists" should "return a valid result" in {
     def airportExists(id: Long): Boolean = repo.doesAirportExist(id).unsafeRunSync()
     airportExists(1) shouldBe true
@@ -259,7 +262,7 @@ class AirportRepositoryIT extends RepositoryCheck {
 
   it should "also allow changing the name field to a new non-empty value" in {
     val original = repo.getAirports("name", newAirport.name).unsafeRunSync().value.value.head
-    val updated = original.copy(name = s"${original.name}_updated")
+    val updated = original.copy(name = updatedName)
     repo.updateAirport(updated).unsafeRunSync().value.value shouldBe updated.id
 
     repo
@@ -283,10 +286,9 @@ class AirportRepositoryIT extends RepositoryCheck {
       .value shouldBe EntryHasInvalidForeignKey
   }
 
-  "Patching an airport" should "work and return the updated airport ID" in {
-    val original =
-      repo.getAirports("name", s"${newAirport.name}_updated").unsafeRunSync().value.value.head
-    val patch = AirportPatch(name = Some(s"${newAirport.name}_patched"))
+  "Patching an airport" should "work and return the updated airport" in {
+    val original = repo.getAirports("name", updatedName).unsafeRunSync().value.value.head
+    val patch = AirportPatch(name = Some(patchedName))
     val patched = Airport.fromPatch(original.id, patch, original)
     repo.partiallyUpdateAirport(original.id, patch).unsafeRunSync().value.value shouldBe patched
   }
@@ -301,8 +303,7 @@ class AirportRepositoryIT extends RepositoryCheck {
   }
 
   it should "throw a foreign key error if the city does not exist" in {
-    val original =
-      repo.getAirports("name", s"${newAirport.name}_patched").unsafeRunSync().value.value.head
+    val original = repo.getAirports("name", patchedName).unsafeRunSync().value.value.head
     val patch = AirportPatch(cityId = Some(idNotPresent))
     repo
       .partiallyUpdateAirport(original.id, patch)
@@ -312,8 +313,7 @@ class AirportRepositoryIT extends RepositoryCheck {
   }
 
   "Removing an airplane" should "work correctly" in {
-    val original =
-      repo.getAirports("name", s"${newAirport.name}_patched").unsafeRunSync().value.value.head
+    val original = repo.getAirports("name", patchedName).unsafeRunSync().value.value.head
     repo.removeAirport(original.id).unsafeRunSync().value.value shouldBe ()
     repo.doesAirportExist(original.id).unsafeRunSync() shouldBe false
   }

--- a/src/it/scala/flightdatabase/repository/AirportRepositoryIT.scala
+++ b/src/it/scala/flightdatabase/repository/AirportRepositoryIT.scala
@@ -2,58 +2,323 @@ package flightdatabase.repository
 
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
+import flightdatabase.domain.ApiResult
+import flightdatabase.domain.EntryAlreadyExists
+import flightdatabase.domain.EntryCheckFailed
+import flightdatabase.domain.EntryHasInvalidForeignKey
+import flightdatabase.domain.EntryListEmpty
+import flightdatabase.domain.EntryNotFound
 import flightdatabase.domain.airport.Airport
+import flightdatabase.domain.airport.AirportCreate
+import flightdatabase.domain.airport.AirportPatch
+import flightdatabase.domain.country.Country
 import flightdatabase.testutils.RepositoryCheck
+import flightdatabase.utils.FieldValue
 
 class AirportRepositoryIT extends RepositoryCheck {
 
-  "Selecting all airports" should "return the correct detailed list" in {
-    val airports = {
-      for {
-        repo        <- AirportRepository.make[IO]
-        allAirports <- repo.getAirports
-      } yield allAirports
-    }.unsafeRunSync().value.value
+  lazy val repo: AirportRepository[IO] = AirportRepository.make[IO].unsafeRunSync()
 
-    airports should not be empty
-    airports should contain only (
-      Airport(
-        1,
-        "Frankfurt am Main Airport",
-        "EDDF",
-        "FRA",
-        2,
-        4,
-        3,
-        65000000,
-        international = true,
-        junction = true
-      ),
-      Airport(
-        2,
-        "Kempegowda International Airport",
-        "VOBL",
-        "BLR",
-        1,
-        2,
-        2,
-        16800000,
-        international = true,
-        junction = false
-      ),
-      Airport(
-        3,
-        "Dubai International Airport",
-        "OMDB",
-        "DXB",
-        4,
-        2,
-        3,
-        92500000,
-        international = true,
-        junction = false
-      )
+  val originalAirports: List[Airport] = List(
+    Airport(
+      1,
+      "Frankfurt am Main Airport",
+      "EDDF",
+      "FRA",
+      2,
+      4,
+      3,
+      65000000,
+      international = true,
+      junction = true
+    ),
+    Airport(
+      2,
+      "Kempegowda International Airport",
+      "VOBL",
+      "BLR",
+      1,
+      2,
+      2,
+      16800000,
+      international = true,
+      junction = false
+    ),
+    Airport(
+      3,
+      "Dubai International Airport",
+      "OMDB",
+      "DXB",
+      4,
+      2,
+      3,
+      92500000,
+      international = true,
+      junction = false
     )
+  )
+
+  val cityToIdMap: Map[String, Long] = Map("Frankfurt am Main" -> 2, "Bangalore" -> 1, "Dubai" -> 4)
+
+  val countryToCityIdMap: Map[String, Long] =
+    Map("Germany" -> 2, "India" -> 1, "United Arab Emirates" -> 4)
+  val idNotPresent: Long = 10
+  val valueNotPresent: String = "Not present"
+  val veryLongIdNotPresent: Long = 1039495454540034858L
+
+  val newAirport: AirportCreate = AirportCreate(
+    "Chhatrapati Shivaji Maharaj International Airport",
+    "VABB",
+    "BOM",
+    1,
+    2,
+    2,
+    50000000,
+    international = true,
+    junction = false
+  )
+
+  "Checking if an airport exists" should "return a valid result" in {
+    def airportExists(id: Long): Boolean = repo.doesAirportExist(id).unsafeRunSync()
+    airportExists(1) shouldBe true
+    airportExists(idNotPresent) shouldBe false
+    airportExists(veryLongIdNotPresent) shouldBe false
   }
 
+  "Selecting all airports" should "return the correct detailed list" in {
+    val airports = repo.getAirports.unsafeRunSync().value.value
+
+    airports should not be empty
+    airports should contain only (originalAirports: _*)
+  }
+
+  it should "return only names if so required" in {
+    val airportsOnlyNames = repo.getAirportsOnlyNames.unsafeRunSync().value.value
+    airportsOnlyNames should not be empty
+    airportsOnlyNames should contain only (originalAirports.map(_.name): _*)
+  }
+
+  "Selecting an airport by id" should "return the correct entry" in {
+    def airportById(id: Long): ApiResult[Airport] = repo.getAirport(id).unsafeRunSync()
+
+    originalAirports.foreach(airport => airportById(airport.id).value.value shouldBe airport)
+    airportById(idNotPresent).left.value shouldBe EntryNotFound(idNotPresent)
+    airportById(veryLongIdNotPresent).left.value shouldBe EntryNotFound(veryLongIdNotPresent)
+  }
+
+  "Selecting airports by other fields" should "return the corresponding entries" in {
+    def airportByName(name: String): ApiResult[List[Airport]] =
+      repo.getAirports("name", name).unsafeRunSync()
+    def airportByIcao(icao: String): ApiResult[List[Airport]] =
+      repo.getAirports("icao", icao).unsafeRunSync()
+    def airportByIata(iata: String): ApiResult[List[Airport]] =
+      repo.getAirports("iata", iata).unsafeRunSync()
+    def airportByCityId(id: Long): ApiResult[List[Airport]] =
+      repo.getAirports("city_id", id).unsafeRunSync()
+
+    val distinctCityIds = originalAirports.map(_.cityId).distinct
+
+    originalAirports.foreach { airport =>
+      airportByName(airport.name).value.value should contain only airport
+      airportByIata(airport.iata).value.value should contain only airport
+      airportByIcao(airport.icao).value.value should contain only airport
+    }
+
+    distinctCityIds.foreach { id =>
+      val expectedAirports = originalAirports.filter(_.cityId == id)
+      airportByCityId(id).value.value should contain only (expectedAirports: _*)
+    }
+
+    airportByName(valueNotPresent).left.value shouldBe EntryListEmpty
+    airportByIata(valueNotPresent).left.value shouldBe EntryListEmpty
+    airportByIcao(valueNotPresent).left.value shouldBe EntryListEmpty
+    airportByCityId(idNotPresent).left.value shouldBe EntryListEmpty
+    airportByCityId(veryLongIdNotPresent).left.value shouldBe EntryListEmpty
+  }
+
+  "Selecting airports by city name" should "return the corresponding entries" in {
+    def airportByCity(city: String): ApiResult[List[Airport]] =
+      repo.getAirportsByCity(city).unsafeRunSync()
+
+    cityToIdMap.foreach {
+      case (city, id) =>
+        airportByCity(city).value.value should contain only (
+          originalAirports.filter(_.cityId == id): _*
+        )
+    }
+
+    airportByCity(valueNotPresent).left.value shouldBe EntryListEmpty
+  }
+
+  "Selecting airport by country" should "also return the corresponding entries" in {
+    def airportByCountry(country: String): ApiResult[List[Airport]] =
+      repo.getAirportsByCountry(country).unsafeRunSync()
+
+    countryToCityIdMap.foreach {
+      case (country, cityId) =>
+        airportByCountry(country).value.value should contain only (
+          originalAirports.filter(_.cityId == cityId): _*
+        )
+    }
+
+    val fv = FieldValue[Country, String]("name", valueNotPresent)
+    airportByCountry(valueNotPresent).left.value shouldBe EntryNotFound(fv)
+  }
+
+  "Creating a new airport" should "not take place for an airport with empty important fields" in {
+    val newAirportWithEmptyName = newAirport.copy(name = "")
+    repo
+      .createAirport(newAirportWithEmptyName)
+      .unsafeRunSync()
+      .left
+      .value shouldBe EntryCheckFailed
+
+    val newAirportWithEmptyIcao = newAirport.copy(icao = "")
+    repo
+      .createAirport(newAirportWithEmptyIcao)
+      .unsafeRunSync()
+      .left
+      .value shouldBe EntryCheckFailed
+
+    val newAirportWithEmptyIata = newAirport.copy(iata = "")
+    repo
+      .createAirport(newAirportWithEmptyIata)
+      .unsafeRunSync()
+      .left
+      .value shouldBe EntryCheckFailed
+  }
+
+  it should "not take place for an airport with an existing IATA/ICAO code" in {
+    repo
+      .createAirport(newAirport.copy(iata = originalAirports.head.iata))
+      .unsafeRunSync()
+      .left
+      .value shouldBe EntryAlreadyExists
+
+    repo
+      .createAirport(newAirport.copy(icao = originalAirports.head.icao))
+      .unsafeRunSync()
+      .left
+      .value shouldBe EntryAlreadyExists
+  }
+
+  it should "not take place for an airport with an existing name in the same city" in {
+    val existingCityId = originalAirports.head.cityId
+    val existingName = originalAirports.head.name
+    repo
+      .createAirport(newAirport.copy(cityId = existingCityId, name = existingName))
+      .unsafeRunSync()
+      .left
+      .value shouldBe EntryAlreadyExists
+  }
+
+  it should "throw a foreign key error if the city does not exist" in {
+    repo
+      .createAirport(newAirport.copy(cityId = idNotPresent))
+      .unsafeRunSync()
+      .left
+      .value shouldBe EntryHasInvalidForeignKey
+  }
+
+  it should "throw a check error if we pass negative values" in {
+    repo
+      .createAirport(newAirport.copy(capacity = -1))
+      .unsafeRunSync()
+      .left
+      .value shouldBe EntryCheckFailed
+
+    repo
+      .createAirport(newAirport.copy(numRunways = -1))
+      .unsafeRunSync()
+      .left
+      .value shouldBe EntryCheckFailed
+
+    repo
+      .createAirport(newAirport.copy(numTerminals = -1))
+      .unsafeRunSync()
+      .left
+      .value shouldBe EntryCheckFailed
+  }
+
+  it should "otherwise return the correct id" in {
+    val newId = repo.createAirport(newAirport).unsafeRunSync().value.value
+    val airports = repo.getAirports.unsafeRunSync().value.value
+
+    airports should contain(Airport.fromCreate(newId, newAirport))
+  }
+
+  it should "throw a conflict error if we try to create the same airport again" in {
+    repo.createAirport(newAirport).unsafeRunSync().left.value shouldBe EntryAlreadyExists
+  }
+
+  "Updating an airport" should "work and return the updated airport ID" in {
+    val original = repo.getAirports("name", newAirport.name).unsafeRunSync().value.value.head
+    val updated = original.copy(capacity = original.capacity + 100)
+    repo.updateAirport(updated).unsafeRunSync().value.value shouldBe updated.id
+  }
+
+  it should "also allow changing the name field to a new non-empty value" in {
+    val original = repo.getAirports("name", newAirport.name).unsafeRunSync().value.value.head
+    val updated = original.copy(name = s"${original.name}_updated")
+    repo.updateAirport(updated).unsafeRunSync().value.value shouldBe updated.id
+
+    repo
+      .updateAirport(updated.copy(name = ""))
+      .unsafeRunSync()
+      .left
+      .value shouldBe EntryCheckFailed
+  }
+
+  it should "throw an error if we update a non-existing airport" in {
+    val updated = Airport.fromCreate(idNotPresent, newAirport)
+    repo.updateAirport(updated).unsafeRunSync().left.value shouldBe EntryNotFound(idNotPresent)
+  }
+
+  it should "throw a foreign key error if the city does not exist" in {
+    val updated = Airport.fromCreate(originalAirports.head.id, newAirport)
+    repo
+      .updateAirport(updated.copy(icao = "XXXX", iata = "XXX", cityId = idNotPresent))
+      .unsafeRunSync()
+      .left
+      .value shouldBe EntryHasInvalidForeignKey
+  }
+
+  "Patching an airport" should "work and return the updated airport ID" in {
+    val original =
+      repo.getAirports("name", s"${newAirport.name}_updated").unsafeRunSync().value.value.head
+    val patch = AirportPatch(name = Some(s"${newAirport.name}_patched"))
+    val patched = Airport.fromPatch(original.id, patch, original)
+    repo.partiallyUpdateAirport(original.id, patch).unsafeRunSync().value.value shouldBe patched
+  }
+
+  it should "throw an error if we patch a non-existing airport" in {
+    val patch = AirportPatch(name = Some("Something"))
+    repo
+      .partiallyUpdateAirport(idNotPresent, patch)
+      .unsafeRunSync()
+      .left
+      .value shouldBe EntryNotFound(idNotPresent)
+  }
+
+  it should "throw a foreign key error if the city does not exist" in {
+    val original =
+      repo.getAirports("name", s"${newAirport.name}_patched").unsafeRunSync().value.value.head
+    val patch = AirportPatch(cityId = Some(idNotPresent))
+    repo
+      .partiallyUpdateAirport(original.id, patch)
+      .unsafeRunSync()
+      .left
+      .value shouldBe EntryHasInvalidForeignKey
+  }
+
+  "Removing an airplane" should "work correctly" in {
+    val original =
+      repo.getAirports("name", s"${newAirport.name}_patched").unsafeRunSync().value.value.head
+    repo.removeAirport(original.id).unsafeRunSync().value.value shouldBe ()
+    repo.doesAirportExist(original.id).unsafeRunSync() shouldBe false
+  }
+
+  it should "throw an error if we try to remove a non-existing airport" in {
+    repo.removeAirport(idNotPresent).unsafeRunSync().left.value shouldBe EntryNotFound(idNotPresent)
+  }
 }

--- a/src/it/scala/flightdatabase/repository/CityRepositoryIT.scala
+++ b/src/it/scala/flightdatabase/repository/CityRepositoryIT.scala
@@ -2,81 +2,126 @@ package flightdatabase.repository
 
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
+import flightdatabase.domain.ApiResult
+import flightdatabase.domain.EntryNotFound
 import flightdatabase.domain.city.City
+import flightdatabase.domain.city.CityCreate
 import flightdatabase.testutils.RepositoryCheck
 
 class CityRepositoryIT extends RepositoryCheck {
 
+  lazy val repo: CityRepository[IO] = CityRepository.make[IO].unsafeRunSync()
+
+  val originalCities: List[City] = List(
+    City(
+      1,
+      "Bangalore",
+      1,
+      capital = false,
+      13193000,
+      BigDecimal("12.978889"),
+      BigDecimal("77.591667"),
+      "Asia/Kolkata"
+    ),
+    City(
+      2,
+      "Frankfurt am Main",
+      2,
+      capital = false,
+      791000,
+      BigDecimal("50.110556"),
+      BigDecimal("8.682222"),
+      "Europe/Berlin"
+    ),
+    City(
+      3,
+      "Berlin",
+      2,
+      capital = true,
+      3571000,
+      BigDecimal("52.52"),
+      BigDecimal("13.405"),
+      "Europe/Berlin"
+    ),
+    City(
+      4,
+      "Dubai",
+      4,
+      capital = false,
+      3490000,
+      BigDecimal("23.5"),
+      BigDecimal("54.5"),
+      "Asia/Dubai"
+    ),
+    City(
+      5,
+      "Leiden",
+      5,
+      capital = false,
+      125100,
+      BigDecimal("52.16"),
+      BigDecimal("4.49"),
+      "Europe/Amsterdam"
+    ),
+    City(
+      6,
+      "Chicago",
+      6,
+      capital = false,
+      8901000,
+      BigDecimal("41.85003"),
+      BigDecimal("-87.65005"),
+      "America/Chicago"
+    )
+  )
+
+  val countryToIdMap: Map[String, Long] = Map(
+    "India"                -> 1,
+    "Germany"              -> 2,
+    "United Arab Emirates" -> 4,
+    "Netherlands"          -> 5,
+    "United States"        -> 6
+  )
+
+  val idNotPresent: Long = 10
+  val valueNotPresent: String = "Not present"
+  val veryLongIdNotPresent: Long = 1039495454540034858L
+
+  val newCity: CityCreate = CityCreate(
+    "Munich",
+    2,
+    capital = false,
+    1488000,
+    BigDecimal("48.137222"),
+    BigDecimal("11.575556"),
+    "Europe/Berlin"
+  )
+
+  "Checking if a city exists" should "return a valid result" in {
+    def cityExists(id: Long): Boolean = repo.doesCityExist(id).unsafeRunSync()
+    cityExists(1) shouldBe true
+    cityExists(idNotPresent) shouldBe false
+    cityExists(veryLongIdNotPresent) shouldBe false
+  }
+
   "Selecting all cities" should "return the correct detailed list" in {
-    val cities = {
-      for {
-        repo      <- CityRepository.make[IO]
-        allCities <- repo.getCities
-      } yield allCities
-    }.unsafeRunSync().value.value
+    val cities = repo.getCities.unsafeRunSync().value.value
 
     cities should not be empty
-    cities should contain only (
-      City(
-        1,
-        "Bangalore",
-        1,
-        capital = false,
-        13193000,
-        BigDecimal("12.978889"),
-        BigDecimal("77.591667"),
-        "Asia/Kolkata"
-      ),
-      City(
-        2,
-        "Frankfurt am Main",
-        2,
-        capital = false,
-        791000,
-        BigDecimal("50.110556"),
-        BigDecimal("8.682222"),
-        "Europe/Berlin"
-      ),
-      City(
-        3,
-        "Berlin",
-        2,
-        capital = true,
-        3571000,
-        BigDecimal("52.52"),
-        BigDecimal("13.405"),
-        "Europe/Berlin"
-      ),
-      City(
-        4,
-        "Dubai",
-        4,
-        capital = false,
-        3490000,
-        BigDecimal("23.5"),
-        BigDecimal("54.5"),
-        "Asia/Dubai"
-      ),
-      City(
-        5,
-        "Leiden",
-        5,
-        capital = false,
-        125100,
-        BigDecimal("52.16"),
-        BigDecimal("4.49"),
-        "Europe/Amsterdam"
-      ),
-      City(
-        6,
-        "Chicago",
-        6,
-        capital = false,
-        8901000,
-        BigDecimal("41.85003"),
-        BigDecimal("-87.65005"),
-        "America/Chicago"
-      )
-    )
+    cities should contain only (originalCities: _*)
+  }
+
+  it should "return only names if so required" in {
+    val citiesOnlyNames = repo.getCitiesOnlyNames.unsafeRunSync().value.value
+    citiesOnlyNames should not be empty
+    citiesOnlyNames should contain only (originalCities.map(_.name): _*)
+  }
+
+  "Selecting a city by id" should "return the correct entry" in {
+    def cityById(id: Long): ApiResult[City] = repo.getCity(id).unsafeRunSync()
+
+    originalCities.foreach(city => cityById(city.id).value.value shouldBe city)
+    cityById(idNotPresent).left.value shouldBe EntryNotFound(idNotPresent)
+    cityById(veryLongIdNotPresent).left.value shouldBe EntryNotFound(veryLongIdNotPresent)
   }
 }

--- a/src/it/scala/flightdatabase/repository/CityRepositoryIT.scala
+++ b/src/it/scala/flightdatabase/repository/CityRepositoryIT.scala
@@ -15,7 +15,7 @@ import flightdatabase.domain.city.CityPatch
 import flightdatabase.testutils.RepositoryCheck
 import org.scalatest.Inspectors.forAll
 
-class CityRepositoryIT extends RepositoryCheck {
+final class CityRepositoryIT extends RepositoryCheck {
 
   lazy val repo: CityRepository[IO] = CityRepository.make[IO].unsafeRunSync()
 

--- a/src/it/scala/flightdatabase/repository/CountryRepositoryIT.scala
+++ b/src/it/scala/flightdatabase/repository/CountryRepositoryIT.scala
@@ -14,7 +14,7 @@ import flightdatabase.domain.country.CountryPatch
 import flightdatabase.testutils.RepositoryCheck
 import org.scalatest.Inspectors.forAll
 
-class CountryRepositoryIT extends RepositoryCheck {
+final class CountryRepositoryIT extends RepositoryCheck {
 
   lazy val repo: CountryRepository[IO] = CountryRepository.make[IO].unsafeRunSync()
 

--- a/src/it/scala/flightdatabase/repository/CountryRepositoryIT.scala
+++ b/src/it/scala/flightdatabase/repository/CountryRepositoryIT.scala
@@ -337,7 +337,7 @@ class CountryRepositoryIT extends RepositoryCheck {
     val existingCountry = originalCountries.head
 
     val duplicatePatches = List(
-      CountryPatch(name = Some(newCountry.name)),
+      CountryPatch(name = Some(updatedName)),
       CountryPatch(iso2 = Some(newCountry.iso2)),
       CountryPatch(iso3 = Some(newCountry.iso3)),
       CountryPatch(countryCode = Some(newCountry.countryCode)),
@@ -355,8 +355,7 @@ class CountryRepositoryIT extends RepositoryCheck {
   }
 
   it should "throw an error if a language/currency does not exist" in {
-    val existingCountry =
-      repo.getCountries("name", updatedName).unsafeRunSync().value.value.head
+    val existingCountry = originalCountries.head
 
     val invalidPatches = List(
       CountryPatch(mainLanguageId = Some(idNotPresent)),

--- a/src/it/scala/flightdatabase/repository/CountryRepositoryIT.scala
+++ b/src/it/scala/flightdatabase/repository/CountryRepositoryIT.scala
@@ -2,52 +2,156 @@ package flightdatabase.repository
 
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
+import flightdatabase.domain.ApiResult
+import flightdatabase.domain.EntryListEmpty
+import flightdatabase.domain.EntryNotFound
 import flightdatabase.domain.country.Country
+import flightdatabase.domain.country.CountryCreate
 import flightdatabase.testutils.RepositoryCheck
 
 class CountryRepositoryIT extends RepositoryCheck {
 
+  lazy val repo: CountryRepository[IO] = CountryRepository.make[IO].unsafeRunSync()
+
+  val originalCountries: List[Country] = List(
+    Country(1, "India", "IN", "IND", 91, Some(".co.in"), 7, Some(1), Some(3), 1, "Indian"),
+    Country(2, "Germany", "DE", "DEU", 49, Some(".de"), 2, None, None, 2, "German"),
+    Country(3, "Sweden", "SE", "SWE", 46, Some(".se"), 4, None, None, 3, "Swede"),
+    Country(
+      4,
+      "United Arab Emirates",
+      "AE",
+      "ARE",
+      971,
+      Some(".ae"),
+      5,
+      Some(1),
+      None,
+      4,
+      "Emirati"
+    ),
+    Country(5, "Netherlands", "NL", "NLD", 31, Some(".nl"), 6, None, None, 2, "Dutch"),
+    Country(
+      6,
+      "United States of America",
+      "US",
+      "USA",
+      1,
+      Some(".us"),
+      1,
+      None,
+      None,
+      5,
+      "US citizen"
+    )
+  )
+
+  val idNotPresent: Long = 100
+  val valueNotPresent: String = "NotPresent"
+  val veryLongIdNotPresent: Long = 1039495454540034858L
+
+  val languageToIdMap: Map[String, Long] = Map(
+    "EN" -> 1,
+    "DE" -> 2,
+    "TA" -> 3,
+    "SV" -> 4,
+    "AR" -> 5,
+    "NL" -> 6,
+    "HI" -> 7
+  )
+  val languageIdToIsoMap: Map[Long, String] = languageToIdMap.map(_.swap)
+
+  val currencyToIdMap: Map[String, Long] = Map(
+    "INR" -> 1,
+    "EUR" -> 2,
+    "SEK" -> 3,
+    "AED" -> 4,
+    "USD" -> 5
+  )
+
+  val newCountry: CountryCreate =
+    CountryCreate("NewCountry", "NC", "NCT", 123, Some(".nc"), 5, Some(1), None, 4, "NewCountryian")
+
+  val updatedName: String = "NewCountryUpdated"
+  val patchedName: String = "NewCountryPatched"
+
+  "Checking if a country exists" should "return a valid result" in {
+    def countryExists(id: Long): Boolean = repo.doesCountryExist(id).unsafeRunSync()
+    countryExists(1) shouldBe true
+    countryExists(idNotPresent) shouldBe false
+    countryExists(veryLongIdNotPresent) shouldBe false
+  }
+
   "Selecting all countries" should "return the correct detailed list" in {
-    val countries = {
-      for {
-        repo         <- CountryRepository.make[IO]
-        allCountries <- repo.getCountries
-      } yield allCountries
-    }.unsafeRunSync().value.value
+    val countries = repo.getCountries.unsafeRunSync().value.value
 
     countries should not be empty
-    countries should contain only (
-      Country(1, "India", "IN", "IND", 91, Some(".co.in"), 7, Some(1), Some(3), 1, "Indian"),
-      Country(2, "Germany", "DE", "DEU", 49, Some(".de"), 2, None, None, 2, "German"),
-      Country(3, "Sweden", "SE", "SWE", 46, Some(".se"), 4, None, None, 3, "Swede"),
-      Country(
-        4,
-        "United Arab Emirates",
-        "AE",
-        "ARE",
-        971,
-        Some(".ae"),
-        5,
-        Some(1),
-        None,
-        4,
-        "Emirati"
-      ),
-      Country(5, "Netherlands", "NL", "NLD", 31, Some(".nl"), 6, None, None, 2, "Dutch"),
-      Country(
-        6,
-        "United States of America",
-        "US",
-        "USA",
-        1,
-        Some(".us"),
-        1,
-        None,
-        None,
-        5,
-        "US citizen"
+    countries should contain only (originalCountries: _*)
+  }
+
+  it should "return only names if so required" in {
+    val countries = repo.getCountriesOnlyNames.unsafeRunSync().value.value
+
+    countries should not be empty
+    countries should contain only (originalCountries.map(_.name): _*)
+  }
+
+  "Selecting a country by ID" should "return the correct country" in {
+    def countryById(id: Long): ApiResult[Country] = repo.getCountry(id).unsafeRunSync()
+
+    originalCountries.foreach(c => countryById(c.id).value.value shouldBe c)
+    countryById(idNotPresent).left.value shouldBe EntryNotFound(idNotPresent)
+    countryById(veryLongIdNotPresent).left.value shouldBe EntryNotFound(veryLongIdNotPresent)
+  }
+
+  "Selecting a country by other fields" should "return the corresponding entries" in {
+    def countryByName(name: String): ApiResult[List[Country]] =
+      repo.getCountries("name", name).unsafeRunSync()
+
+    def countryByIso2(iso2: String): ApiResult[List[Country]] =
+      repo.getCountries("iso2", iso2).unsafeRunSync()
+
+    def countryByNationality(nationality: String): ApiResult[List[Country]] =
+      repo.getCountries("nationality", nationality).unsafeRunSync()
+
+    def countryByLanguage(id: Long): ApiResult[List[Country]] =
+      repo.getCountriesByLanguage("id", id).unsafeRunSync()
+
+    def countryByCurrency(id: Long): ApiResult[List[Country]] =
+      repo.getCountriesByCurrency("id", id).unsafeRunSync()
+
+    val distinctLanguageIds = {
+      originalCountries.flatMap(c =>
+        List(Some(c.mainLanguageId), c.secondaryLanguageId, c.tertiaryLanguageId).flatten
       )
-    )
+    }.distinct
+
+    val distinctCurrencyIds = originalCountries.map(_.currencyId).distinct
+
+    originalCountries.foreach { c =>
+      countryByName(c.name).value.value should contain only c
+      countryByIso2(c.iso2).value.value should contain only c
+      countryByNationality(c.nationality).value.value should contain only c
+    }
+
+    distinctLanguageIds.foreach { id =>
+      val expectedCountries = originalCountries.filter(c =>
+        List(Some(c.mainLanguageId), c.secondaryLanguageId, c.tertiaryLanguageId).flatten
+          .contains(id)
+      )
+      countryByLanguage(id).value.value should contain only (expectedCountries: _*)
+    }
+
+    distinctCurrencyIds.foreach { id =>
+      val expectedCountries = originalCountries.filter(_.currencyId == id)
+      countryByCurrency(id).value.value should contain only (expectedCountries: _*)
+    }
+
+    countryByName(valueNotPresent).left.value shouldBe EntryListEmpty
+    countryByIso2(valueNotPresent).left.value shouldBe EntryListEmpty
+    countryByNationality(valueNotPresent).left.value shouldBe EntryListEmpty
+    countryByLanguage(idNotPresent).left.value shouldBe EntryListEmpty
+    countryByCurrency(idNotPresent).left.value shouldBe EntryListEmpty
   }
 
 }

--- a/src/it/scala/flightdatabase/repository/CountryRepositoryIT.scala
+++ b/src/it/scala/flightdatabase/repository/CountryRepositoryIT.scala
@@ -82,7 +82,7 @@ final class CountryRepositoryIT extends RepositoryCheck {
 
   "Checking if a country exists" should "return a valid result" in {
     def countryExists(id: Long): Boolean = repo.doesCountryExist(id).unsafeRunSync()
-    countryExists(1) shouldBe true
+    forAll(originalCountries)(c => countryExists(c.id) shouldBe true)
     countryExists(idNotPresent) shouldBe false
     countryExists(veryLongIdNotPresent) shouldBe false
   }

--- a/src/it/scala/flightdatabase/repository/CurrencyRepositoryIT.scala
+++ b/src/it/scala/flightdatabase/repository/CurrencyRepositoryIT.scala
@@ -2,26 +2,249 @@ package flightdatabase.repository
 
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
+import flightdatabase.domain.ApiResult
+import flightdatabase.domain.EntryAlreadyExists
+import flightdatabase.domain.EntryCheckFailed
+import flightdatabase.domain.EntryListEmpty
+import flightdatabase.domain.EntryNotFound
+import flightdatabase.domain.UnknownDbError
 import flightdatabase.domain.currency.Currency
+import flightdatabase.domain.currency.CurrencyCreate
+import flightdatabase.domain.currency.CurrencyPatch
 import flightdatabase.testutils.RepositoryCheck
+import org.scalatest.Inspectors.forAll
 
 final class CurrencyRepositoryIT extends RepositoryCheck {
 
+  lazy val repo: CurrencyRepository[IO] = CurrencyRepository.make[IO].unsafeRunSync()
+
+  val originalCurrencies: List[Currency] = List(
+    Currency(1, "Indian Rupee", "INR", Some("₹")),
+    Currency(2, "Euro", "EUR", Some("€")),
+    Currency(3, "Swedish Krona", "SEK", Some("kr")),
+    Currency(4, "Dirham", "AED", None),
+    Currency(5, "US Dollar", "USD", Some("$"))
+  )
+
+  val idNotPresent: Long = 100
+  val valueNotPresent: String = "Not present"
+  val veryLongIdNotPresent: Long = 1000000000000000000L
+  val stringTooLongSqlState: String = "22001"
+
+  val newCurrency: CurrencyCreate = CurrencyCreate("New Currency", "NCR", Some("NCR"))
+  val updatedName: String = "Updated Currency"
+  val patchedName: String = "Patched Currency"
+
+  "Checking if a currency exists" should "return a valid result" in {
+    def currencyExists(id: Long): Boolean = repo.doesCurrencyExist(id).unsafeRunSync()
+    currencyExists(1) shouldBe true
+    currencyExists(idNotPresent) shouldBe false
+    currencyExists(veryLongIdNotPresent) shouldBe false
+  }
+
   "Selecting all currencies" should "return the correct detailed list" in {
-    val currencies = {
-      for {
-        repo          <- CurrencyRepository.make[IO]
-        allCurrencies <- repo.getCurrencies
-      } yield allCurrencies
-    }.unsafeRunSync().value.value
+    val currencies = repo.getCurrencies.unsafeRunSync().value.value
 
     currencies should not be empty
-    currencies should contain only (
-      Currency(1, "Indian Rupee", "INR", Some("₹")),
-      Currency(2, "Euro", "EUR", Some("€")),
-      Currency(3, "Swedish Krona", "SEK", Some("kr")),
-      Currency(4, "Dirham", "AED", None),
-      Currency(5, "US Dollar", "USD", Some("$"))
+    currencies should contain only (originalCurrencies: _*)
+  }
+
+  it should "only return names if so required" in {
+    val currencyNames = repo.getCurrenciesOnlyNames.unsafeRunSync().value.value
+
+    currencyNames should not be empty
+    currencyNames should contain only (originalCurrencies.map(_.name): _*)
+  }
+
+  "Selecting a currency by ID" should "return the correct currency" in {
+    def currencyById(id: Long): ApiResult[Currency] = repo.getCurrency(id).unsafeRunSync()
+
+    forAll(originalCurrencies)(currency => currencyById(currency.id).value.value shouldBe currency)
+    currencyById(idNotPresent).left.value shouldBe EntryNotFound(idNotPresent)
+    currencyById(veryLongIdNotPresent).left.value shouldBe EntryNotFound(veryLongIdNotPresent)
+  }
+
+  "Selecting a currency by other fields" should "return the corresponding entries" in {
+    def currencyByName(name: String): ApiResult[List[Currency]] =
+      repo.getCurrencies("name", name).unsafeRunSync()
+
+    def currencyByIso(iso: String): ApiResult[List[Currency]] =
+      repo.getCurrencies("iso", iso).unsafeRunSync()
+
+    forAll(originalCurrencies) { currency =>
+      currencyByName(currency.name).value.value should contain only currency
+      currencyByIso(currency.iso).value.value should contain only currency
+    }
+
+    currencyByName(valueNotPresent).left.value shouldBe EntryListEmpty
+    currencyByIso(valueNotPresent).left.value shouldBe EntryListEmpty
+  }
+
+  "Creating a new currency" should "not take place if fields do not satisfy their criteria" in {
+    val invalidCurrencies = List(
+      newCurrency.copy(name = ""),
+      newCurrency.copy(iso = "")
+    )
+
+    forAll(invalidCurrencies) { currency =>
+      repo.createCurrency(currency).unsafeRunSync().left.value shouldBe EntryCheckFailed
+    }
+
+    val invalidSymbol = newCurrency.copy(symbol = Some("Something too long"))
+    repo.createCurrency(invalidSymbol).unsafeRunSync().left.value shouldBe UnknownDbError(
+      stringTooLongSqlState
+    )
+  }
+
+  it should "not take place for a currency with existing unique fields" in {
+    val existingCurrency = originalCurrencies.head
+
+    val duplicateCurrencies = List(
+      newCurrency.copy(iso = existingCurrency.iso),
+      newCurrency.copy(symbol = existingCurrency.symbol)
+    )
+
+    forAll(duplicateCurrencies) { currency =>
+      repo.createCurrency(currency).unsafeRunSync().left.value shouldBe EntryAlreadyExists
+    }
+  }
+
+  it should "work if all criteria are met" in {
+    val newCurrencyId = repo.createCurrency(newCurrency).unsafeRunSync().value.value
+    val newCurrencyFromDb = repo.getCurrency(newCurrencyId).unsafeRunSync().value.value
+
+    newCurrencyFromDb shouldBe Currency.fromCreate(newCurrencyId, newCurrency)
+  }
+
+  it should "throw a conflict error if we create the same currency again" in {
+    repo.createCurrency(newCurrency).unsafeRunSync().left.value shouldBe EntryAlreadyExists
+  }
+
+  "Updating a currency" should "not take place if fields do not satisfy their criteria" in {
+    val existingCurrency = originalCurrencies.head
+
+    val invalidCurrencies = List(
+      existingCurrency.copy(name = ""),
+      existingCurrency.copy(iso = "")
+    )
+
+    forAll(invalidCurrencies) { currency =>
+      repo.updateCurrency(currency).unsafeRunSync().left.value shouldBe EntryCheckFailed
+    }
+
+    val invalidSymbol = existingCurrency.copy(symbol = Some("Something too long"))
+    repo.updateCurrency(invalidSymbol).unsafeRunSync().left.value shouldBe UnknownDbError(
+      stringTooLongSqlState
+    )
+  }
+
+  it should "not take place for a currency with existing unique fields" in {
+    val existingCurrency = originalCurrencies.head
+
+    val duplicateCurrencies = List(
+      existingCurrency.copy(iso = newCurrency.iso),
+      existingCurrency.copy(symbol = newCurrency.symbol)
+    )
+
+    forAll(duplicateCurrencies) { currency =>
+      repo.updateCurrency(currency).unsafeRunSync().left.value shouldBe EntryAlreadyExists
+    }
+  }
+
+  it should "throw an error if we update a currency that does not exist" in {
+    val updated = Currency.fromCreate(idNotPresent, newCurrency)
+    repo.updateCurrency(updated).unsafeRunSync().left.value shouldBe EntryNotFound(idNotPresent)
+  }
+
+  it should "work if all criteria are met" in {
+    val existingCurrency =
+      repo.getCurrencies("name", newCurrency.name).unsafeRunSync().value.value.head
+    val updated = existingCurrency.copy(name = updatedName)
+
+    repo.updateCurrency(updated).unsafeRunSync().value.value shouldBe existingCurrency.id
+
+    val updatedCurrencyFromDb = repo.getCurrency(existingCurrency.id).unsafeRunSync().value.value
+    updatedCurrencyFromDb shouldBe updated
+  }
+
+  "Patching a currency" should "not take place if fields do not satisfy their criteria" in {
+    val existingCurrency = originalCurrencies.head
+
+    val invalidCurrencies = List(
+      CurrencyPatch(name = Some("")),
+      CurrencyPatch(iso = Some(""))
+    )
+
+    forAll(invalidCurrencies) { patch =>
+      repo
+        .partiallyUpdateCurrency(existingCurrency.id, patch)
+        .unsafeRunSync()
+        .left
+        .value shouldBe EntryCheckFailed
+    }
+
+    val invalidSymbol = CurrencyPatch(symbol = Some("Something too long"))
+    repo
+      .partiallyUpdateCurrency(existingCurrency.id, invalidSymbol)
+      .unsafeRunSync()
+      .left
+      .value shouldBe UnknownDbError(stringTooLongSqlState)
+  }
+
+  it should "not take place for a currency with existing unique fields" in {
+    val existingCurrency = originalCurrencies.head
+
+    val duplicateCurrencies = List(
+      CurrencyPatch(iso = Some(newCurrency.iso)),
+      CurrencyPatch(symbol = newCurrency.symbol)
+    )
+
+    forAll(duplicateCurrencies) { patch =>
+      repo
+        .partiallyUpdateCurrency(existingCurrency.id, patch)
+        .unsafeRunSync()
+        .left
+        .value shouldBe EntryAlreadyExists
+    }
+  }
+
+  it should "throw an error if we patch a currency that does not exist" in {
+    val patched = CurrencyPatch(name = Some(patchedName))
+    repo
+      .partiallyUpdateCurrency(idNotPresent, patched)
+      .unsafeRunSync()
+      .left
+      .value shouldBe EntryNotFound(idNotPresent)
+  }
+
+  it should "work if all criteria are met" in {
+    val existingCurrency =
+      repo.getCurrencies("name", updatedName).unsafeRunSync().value.value.head
+    val patched = CurrencyPatch(name = Some(patchedName))
+
+    repo
+      .partiallyUpdateCurrency(existingCurrency.id, patched)
+      .unsafeRunSync()
+      .value
+      .value
+      .name shouldBe patchedName
+
+    val patchedCurrencyFromDb = repo.getCurrency(existingCurrency.id).unsafeRunSync().value.value
+    patchedCurrencyFromDb.name shouldBe patchedName
+  }
+
+  "Removing a currency" should "work correctly" in {
+    val existingCurrency = repo.getCurrencies("name", patchedName).unsafeRunSync().value.value.head
+    repo.removeCurrency(existingCurrency.id).unsafeRunSync().value.value shouldBe ()
+
+    repo.getCurrency(existingCurrency.id).unsafeRunSync().left.value shouldBe EntryNotFound(
+      existingCurrency.id
+    )
+  }
+
+  it should "not work if the currency does not exist" in {
+    repo.removeCurrency(idNotPresent).unsafeRunSync().left.value shouldBe EntryNotFound(
+      idNotPresent
     )
   }
 }

--- a/src/it/scala/flightdatabase/repository/CurrencyRepositoryIT.scala
+++ b/src/it/scala/flightdatabase/repository/CurrencyRepositoryIT.scala
@@ -226,8 +226,7 @@ final class CurrencyRepositoryIT extends RepositoryCheck {
       .partiallyUpdateCurrency(existingCurrency.id, patched)
       .unsafeRunSync()
       .value
-      .value
-      .name shouldBe patchedName
+      .value shouldBe existingCurrency.copy(name = patchedName)
 
     val patchedCurrencyFromDb = repo.getCurrency(existingCurrency.id).unsafeRunSync().value.value
     patchedCurrencyFromDb.name shouldBe patchedName

--- a/src/it/scala/flightdatabase/repository/CurrencyRepositoryIT.scala
+++ b/src/it/scala/flightdatabase/repository/CurrencyRepositoryIT.scala
@@ -12,6 +12,7 @@ import flightdatabase.domain.currency.Currency
 import flightdatabase.domain.currency.CurrencyCreate
 import flightdatabase.domain.currency.CurrencyPatch
 import flightdatabase.testutils.RepositoryCheck
+import flightdatabase.testutils.implicits.enrichIOOperation
 import org.scalatest.Inspectors.forAll
 
 final class CurrencyRepositoryIT extends RepositoryCheck {
@@ -43,41 +44,37 @@ final class CurrencyRepositoryIT extends RepositoryCheck {
   }
 
   "Selecting all currencies" should "return the correct detailed list" in {
-    val currencies = repo.getCurrencies.unsafeRunSync().value.value
+    val currencies = repo.getCurrencies.value
 
     currencies should not be empty
     currencies should contain only (originalCurrencies: _*)
   }
 
   it should "only return names if so required" in {
-    val currencyNames = repo.getCurrenciesOnlyNames.unsafeRunSync().value.value
+    val currencyNames = repo.getCurrenciesOnlyNames.value
 
     currencyNames should not be empty
     currencyNames should contain only (originalCurrencies.map(_.name): _*)
   }
 
   "Selecting a currency by ID" should "return the correct currency" in {
-    def currencyById(id: Long): ApiResult[Currency] = repo.getCurrency(id).unsafeRunSync()
-
-    forAll(originalCurrencies)(currency => currencyById(currency.id).value.value shouldBe currency)
-    currencyById(idNotPresent).left.value shouldBe EntryNotFound(idNotPresent)
-    currencyById(veryLongIdNotPresent).left.value shouldBe EntryNotFound(veryLongIdNotPresent)
+    forAll(originalCurrencies)(currency => repo.getCurrency(currency.id).value shouldBe currency)
+    repo.getCurrency(idNotPresent).error shouldBe EntryNotFound(idNotPresent)
+    repo.getCurrency(veryLongIdNotPresent).error shouldBe EntryNotFound(veryLongIdNotPresent)
   }
 
   "Selecting a currency by other fields" should "return the corresponding entries" in {
-    def currencyByName(name: String): ApiResult[List[Currency]] =
-      repo.getCurrencies("name", name).unsafeRunSync()
-
-    def currencyByIso(iso: String): ApiResult[List[Currency]] =
-      repo.getCurrencies("iso", iso).unsafeRunSync()
+    def currencyByName(name: String): IO[ApiResult[List[Currency]]] =
+      repo.getCurrencies("name", name)
+    def currencyByIso(iso: String): IO[ApiResult[List[Currency]]] = repo.getCurrencies("iso", iso)
 
     forAll(originalCurrencies) { currency =>
-      currencyByName(currency.name).value.value should contain only currency
-      currencyByIso(currency.iso).value.value should contain only currency
+      currencyByName(currency.name).value should contain only currency
+      currencyByIso(currency.iso).value should contain only currency
     }
 
-    currencyByName(valueNotPresent).left.value shouldBe EntryListEmpty
-    currencyByIso(valueNotPresent).left.value shouldBe EntryListEmpty
+    currencyByName(valueNotPresent).error shouldBe EntryListEmpty
+    currencyByIso(valueNotPresent).error shouldBe EntryListEmpty
   }
 
   "Creating a new currency" should "not take place if fields do not satisfy their criteria" in {
@@ -87,13 +84,11 @@ final class CurrencyRepositoryIT extends RepositoryCheck {
     )
 
     forAll(invalidCurrencies) { currency =>
-      repo.createCurrency(currency).unsafeRunSync().left.value shouldBe EntryCheckFailed
+      repo.createCurrency(currency).error shouldBe EntryCheckFailed
     }
 
     val invalidSymbol = newCurrency.copy(symbol = Some("Something too long"))
-    repo.createCurrency(invalidSymbol).unsafeRunSync().left.value shouldBe UnknownDbError(
-      stringTooLongSqlState
-    )
+    repo.createCurrency(invalidSymbol).error shouldBe UnknownDbError(stringTooLongSqlState)
   }
 
   it should "not take place for a currency with existing unique fields" in {
@@ -105,19 +100,19 @@ final class CurrencyRepositoryIT extends RepositoryCheck {
     )
 
     forAll(duplicateCurrencies) { currency =>
-      repo.createCurrency(currency).unsafeRunSync().left.value shouldBe EntryAlreadyExists
+      repo.createCurrency(currency).error shouldBe EntryAlreadyExists
     }
   }
 
   it should "work if all criteria are met" in {
-    val newCurrencyId = repo.createCurrency(newCurrency).unsafeRunSync().value.value
-    val newCurrencyFromDb = repo.getCurrency(newCurrencyId).unsafeRunSync().value.value
+    val newCurrencyId = repo.createCurrency(newCurrency).value
+    val newCurrencyFromDb = repo.getCurrency(newCurrencyId).value
 
     newCurrencyFromDb shouldBe Currency.fromCreate(newCurrencyId, newCurrency)
   }
 
   it should "throw a conflict error if we create the same currency again" in {
-    repo.createCurrency(newCurrency).unsafeRunSync().left.value shouldBe EntryAlreadyExists
+    repo.createCurrency(newCurrency).error shouldBe EntryAlreadyExists
   }
 
   "Updating a currency" should "not take place if fields do not satisfy their criteria" in {
@@ -129,13 +124,11 @@ final class CurrencyRepositoryIT extends RepositoryCheck {
     )
 
     forAll(invalidCurrencies) { currency =>
-      repo.updateCurrency(currency).unsafeRunSync().left.value shouldBe EntryCheckFailed
+      repo.updateCurrency(currency).error shouldBe EntryCheckFailed
     }
 
     val invalidSymbol = existingCurrency.copy(symbol = Some("Something too long"))
-    repo.updateCurrency(invalidSymbol).unsafeRunSync().left.value shouldBe UnknownDbError(
-      stringTooLongSqlState
-    )
+    repo.updateCurrency(invalidSymbol).error shouldBe UnknownDbError(stringTooLongSqlState)
   }
 
   it should "not take place for a currency with existing unique fields" in {
@@ -147,23 +140,22 @@ final class CurrencyRepositoryIT extends RepositoryCheck {
     )
 
     forAll(duplicateCurrencies) { currency =>
-      repo.updateCurrency(currency).unsafeRunSync().left.value shouldBe EntryAlreadyExists
+      repo.updateCurrency(currency).error shouldBe EntryAlreadyExists
     }
   }
 
   it should "throw an error if we update a currency that does not exist" in {
     val updated = Currency.fromCreate(idNotPresent, newCurrency)
-    repo.updateCurrency(updated).unsafeRunSync().left.value shouldBe EntryNotFound(idNotPresent)
+    repo.updateCurrency(updated).error shouldBe EntryNotFound(idNotPresent)
   }
 
   it should "work if all criteria are met" in {
-    val existingCurrency =
-      repo.getCurrencies("name", newCurrency.name).unsafeRunSync().value.value.head
+    val existingCurrency = repo.getCurrencies("name", newCurrency.name).value.head
     val updated = existingCurrency.copy(name = updatedName)
 
-    repo.updateCurrency(updated).unsafeRunSync().value.value shouldBe existingCurrency.id
+    repo.updateCurrency(updated).value shouldBe existingCurrency.id
 
-    val updatedCurrencyFromDb = repo.getCurrency(existingCurrency.id).unsafeRunSync().value.value
+    val updatedCurrencyFromDb = repo.getCurrency(existingCurrency.id).value
     updatedCurrencyFromDb shouldBe updated
   }
 
@@ -176,19 +168,13 @@ final class CurrencyRepositoryIT extends RepositoryCheck {
     )
 
     forAll(invalidCurrencies) { patch =>
-      repo
-        .partiallyUpdateCurrency(existingCurrency.id, patch)
-        .unsafeRunSync()
-        .left
-        .value shouldBe EntryCheckFailed
+      repo.partiallyUpdateCurrency(existingCurrency.id, patch).error shouldBe EntryCheckFailed
     }
 
     val invalidSymbol = CurrencyPatch(symbol = Some("Something too long"))
     repo
       .partiallyUpdateCurrency(existingCurrency.id, invalidSymbol)
-      .unsafeRunSync()
-      .left
-      .value shouldBe UnknownDbError(stringTooLongSqlState)
+      .error shouldBe UnknownDbError(stringTooLongSqlState)
   }
 
   it should "not take place for a currency with existing unique fields" in {
@@ -200,50 +186,35 @@ final class CurrencyRepositoryIT extends RepositoryCheck {
     )
 
     forAll(duplicateCurrencies) { patch =>
-      repo
-        .partiallyUpdateCurrency(existingCurrency.id, patch)
-        .unsafeRunSync()
-        .left
-        .value shouldBe EntryAlreadyExists
+      repo.partiallyUpdateCurrency(existingCurrency.id, patch).error shouldBe EntryAlreadyExists
     }
   }
 
   it should "throw an error if we patch a currency that does not exist" in {
     val patched = CurrencyPatch(name = Some(patchedName))
-    repo
-      .partiallyUpdateCurrency(idNotPresent, patched)
-      .unsafeRunSync()
-      .left
-      .value shouldBe EntryNotFound(idNotPresent)
+    repo.partiallyUpdateCurrency(idNotPresent, patched).error shouldBe EntryNotFound(idNotPresent)
   }
 
   it should "work if all criteria are met" in {
-    val existingCurrency =
-      repo.getCurrencies("name", updatedName).unsafeRunSync().value.value.head
+    val existingCurrency = repo.getCurrencies("name", updatedName).value.head
     val patched = CurrencyPatch(name = Some(patchedName))
 
     repo
       .partiallyUpdateCurrency(existingCurrency.id, patched)
-      .unsafeRunSync()
-      .value
       .value shouldBe existingCurrency.copy(name = patchedName)
 
-    val patchedCurrencyFromDb = repo.getCurrency(existingCurrency.id).unsafeRunSync().value.value
+    val patchedCurrencyFromDb = repo.getCurrency(existingCurrency.id).value
     patchedCurrencyFromDb.name shouldBe patchedName
   }
 
   "Removing a currency" should "work correctly" in {
-    val existingCurrency = repo.getCurrencies("name", patchedName).unsafeRunSync().value.value.head
-    repo.removeCurrency(existingCurrency.id).unsafeRunSync().value.value shouldBe ()
+    val existingCurrency = repo.getCurrencies("name", patchedName).value.head
+    repo.removeCurrency(existingCurrency.id).value shouldBe ()
 
-    repo.getCurrency(existingCurrency.id).unsafeRunSync().left.value shouldBe EntryNotFound(
-      existingCurrency.id
-    )
+    repo.getCurrency(existingCurrency.id).error shouldBe EntryNotFound(existingCurrency.id)
   }
 
   it should "not work if the currency does not exist" in {
-    repo.removeCurrency(idNotPresent).unsafeRunSync().left.value shouldBe EntryNotFound(
-      idNotPresent
-    )
+    repo.removeCurrency(idNotPresent).error shouldBe EntryNotFound(idNotPresent)
   }
 }

--- a/src/it/scala/flightdatabase/repository/FleetAirplaneRepositoryIT.scala
+++ b/src/it/scala/flightdatabase/repository/FleetAirplaneRepositoryIT.scala
@@ -5,7 +5,7 @@ import cats.effect.unsafe.implicits.global
 import flightdatabase.domain.fleet_airplane.FleetAirplane
 import flightdatabase.testutils.RepositoryCheck
 
-class FleetAirplaneRepositoryIT extends RepositoryCheck {
+final class FleetAirplaneRepositoryIT extends RepositoryCheck {
 
   "Selecting all fleet airplanes" should "return the correct detailed list" in {
     val fleetAirplanes = {

--- a/src/it/scala/flightdatabase/repository/FleetAirplaneRepositoryIT.scala
+++ b/src/it/scala/flightdatabase/repository/FleetAirplaneRepositoryIT.scala
@@ -2,26 +2,265 @@ package flightdatabase.repository
 
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
+import flightdatabase.domain.ApiResult
+import flightdatabase.domain.EntryAlreadyExists
+import flightdatabase.domain.EntryHasInvalidForeignKey
+import flightdatabase.domain.EntryListEmpty
+import flightdatabase.domain.EntryNotFound
+import flightdatabase.domain.fleet.Fleet
 import flightdatabase.domain.fleet_airplane.FleetAirplane
+import flightdatabase.domain.fleet_airplane.FleetAirplaneCreate
+import flightdatabase.domain.fleet_airplane.FleetAirplanePatch
 import flightdatabase.testutils.RepositoryCheck
+import flightdatabase.testutils.implicits.enrichIOOperation
+import org.scalatest.Inspectors.forAll
 
 final class FleetAirplaneRepositoryIT extends RepositoryCheck {
 
+  lazy val repo: FleetAirplaneRepository[IO] = FleetAirplaneRepository.make[IO].unsafeRunSync()
+
+  val originalFleetAirplanes: List[FleetAirplane] = List(
+    FleetAirplane(1, 1, 2),
+    FleetAirplane(2, 1, 1),
+    FleetAirplane(3, 1, 3),
+    FleetAirplane(4, 2, 1),
+    FleetAirplane(5, 2, 3)
+  )
+
+  val idNotPresent: Long = 100
+  val valueNotPresent: String = "Not Present"
+  val veryLongIdNotPresent: Long = 1000000000000000000L
+
+  val fleetIdMap: Map[Long, (String, String)] = Map(
+    1L -> ("Lufthansa", "LH"),
+    2L -> ("Emirates", "EK")
+  )
+
+  val airplaneIdMap: Map[Long, String] = Map(1L -> "A380", 2L -> "747-8", 3L -> "A320neo")
+
+  val newFleetAirplane: FleetAirplaneCreate = FleetAirplaneCreate(2, 2) // EK -> 747-8
+  val updatedAirplane: Long = 4                                         // EK -> 787-8
+  val patchedAirplane: Long = 2                                         // Back to EK -> 747-8
+
+  "Checking if a fleet-airplane exists" should "return a valid result" in {
+    def fleetAirplaneExists(id: Long): Boolean = repo.doesFleetAirplaneExist(id).unsafeRunSync()
+    forAll(originalFleetAirplanes.map(_.id))(id => fleetAirplaneExists(id) shouldBe true)
+    fleetAirplaneExists(idNotPresent) shouldBe false
+    fleetAirplaneExists(veryLongIdNotPresent) shouldBe false
+  }
+
   "Selecting all fleet airplanes" should "return the correct detailed list" in {
-    val fleetAirplanes = {
-      for {
-        repo <- FleetAirplaneRepository.make[IO]
-        all  <- repo.getFleetAirplanes
-      } yield all
-    }.unsafeRunSync().value.value
+    val fleetAirplanes = repo.getFleetAirplanes.value
 
     fleetAirplanes should not be empty
-    fleetAirplanes should contain only (
-      FleetAirplane(1, 1, 2),
-      FleetAirplane(2, 1, 1),
-      FleetAirplane(3, 1, 3),
-      FleetAirplane(4, 2, 1),
-      FleetAirplane(5, 2, 3)
+    fleetAirplanes should contain only (originalFleetAirplanes: _*)
+  }
+
+  "Selecting a fleet airplane by id" should "return the correct detailed fleet airplane" in {
+    forAll(originalFleetAirplanes)(fleetAirplane =>
+      repo.getFleetAirplane(fleetAirplane.id).value shouldBe fleetAirplane
     )
+    repo.getFleetAirplane(idNotPresent).error shouldBe EntryNotFound(idNotPresent)
+    repo.getFleetAirplane(veryLongIdNotPresent).error shouldBe EntryNotFound(veryLongIdNotPresent)
+  }
+
+  "Selecting a fleet airplane by fleet and airplane IDs" should "return the correct detailed fleet airplane" in {
+    def f(fleetId: Long, airplaneId: Long): IO[ApiResult[FleetAirplane]] =
+      repo.getFleetAirplane(fleetId, airplaneId)
+
+    forAll(originalFleetAirplanes)(fleetAirplane =>
+      f(fleetAirplane.fleetId, fleetAirplane.airplaneId).value shouldBe fleetAirplane
+    )
+
+    f(idNotPresent, 1).error shouldBe EntryListEmpty
+    f(1, veryLongIdNotPresent).error shouldBe EntryListEmpty
+  }
+
+  "Selecting fleet airplanes by other fields" should "return the corresponding entries" in {
+    def fleetAirplaneByFleetId(id: Long): IO[ApiResult[List[FleetAirplane]]] =
+      repo.getFleetAirplanes("fleet_id", id)
+
+    def fleetAirplaneByAirplaneId(id: Long): IO[ApiResult[List[FleetAirplane]]] =
+      repo.getFleetAirplanes("airplane_id", id)
+
+    val distinctFleetIds = originalFleetAirplanes.map(_.fleetId).distinct
+    val distinctAirplaneIds = originalFleetAirplanes.map(_.airplaneId).distinct
+
+    forAll(distinctFleetIds) { fleetId =>
+      fleetAirplaneByFleetId(fleetId).value should contain only (
+        originalFleetAirplanes.filter(_.fleetId == fleetId): _*
+      )
+    }
+
+    forAll(distinctAirplaneIds) { airplaneId =>
+      fleetAirplaneByAirplaneId(airplaneId).value should contain only (
+        originalFleetAirplanes.filter(_.airplaneId == airplaneId): _*
+      )
+    }
+
+    fleetAirplaneByFleetId(idNotPresent).error shouldBe EntryListEmpty
+    fleetAirplaneByFleetId(veryLongIdNotPresent).error shouldBe EntryListEmpty
+    fleetAirplaneByAirplaneId(idNotPresent).error shouldBe EntryListEmpty
+    fleetAirplaneByAirplaneId(veryLongIdNotPresent).error shouldBe EntryListEmpty
+  }
+
+  "Selecting fleet airplanes by external fields" should "return the corresponding entries" in {
+    def fleetAirplanesByFleetName(name: String): IO[ApiResult[List[FleetAirplane]]] =
+      repo.getFleetAirplanesByFleetName(name)
+
+    def fleetAirplanesByAirplaneName(name: String): IO[ApiResult[List[FleetAirplane]]] =
+      repo.getFleetAirplanesByAirplaneName(name)
+
+    def fleetAirplanesByFleetIso(iso: String): IO[ApiResult[List[FleetAirplane]]] =
+      repo.getFleetAirplanesByExternal[Fleet, String]("iso2", iso)
+
+    forAll(fleetIdMap) {
+      case (id, (name, iso)) =>
+        fleetAirplanesByFleetName(name).value should contain only (
+          originalFleetAirplanes.filter(_.fleetId == id): _*
+        )
+        fleetAirplanesByFleetIso(iso).value should contain only (
+          originalFleetAirplanes.filter(_.fleetId == id): _*
+        )
+    }
+
+    forAll(airplaneIdMap) {
+      case (id, name) =>
+        fleetAirplanesByAirplaneName(name).value should contain only (
+          originalFleetAirplanes.filter(_.airplaneId == id): _*
+        )
+    }
+
+    fleetAirplanesByFleetName(valueNotPresent).error shouldBe EntryListEmpty
+    fleetAirplanesByFleetIso(valueNotPresent).error shouldBe EntryListEmpty
+    fleetAirplanesByAirplaneName(valueNotPresent).error shouldBe EntryListEmpty
+  }
+
+  "Creating a new fleet-airplane" should "not work if the fleet or airplane does not exist" in {
+    val invalidFleetAirplanes = List(
+      newFleetAirplane.copy(fleetId = idNotPresent),
+      newFleetAirplane.copy(airplaneId = idNotPresent)
+    )
+
+    forAll(invalidFleetAirplanes) { fleetAirplane =>
+      repo
+        .createFleetAirplane(fleetAirplane)
+        .error shouldBe EntryHasInvalidForeignKey
+    }
+  }
+
+  it should "not work if the combination of fleet and airplane already exists" in {
+    val existingFleetAirplane = originalFleetAirplanes.head
+    repo
+      .createFleetAirplane(
+        FleetAirplaneCreate(existingFleetAirplane.fleetId, existingFleetAirplane.airplaneId)
+      )
+      .error shouldBe EntryAlreadyExists
+  }
+
+  it should "work if all criteria are met" in {
+    val newFleetAirplaneId = repo.createFleetAirplane(newFleetAirplane).value
+    val newFleetAirplaneFromDb = repo.getFleetAirplane(newFleetAirplaneId).value
+
+    newFleetAirplaneFromDb shouldBe FleetAirplane.fromCreate(newFleetAirplaneId, newFleetAirplane)
+  }
+
+  "Updating a fleet-airplane" should "not work if the fleet or airplane does not exist" in {
+    val existingFleetAirplane = originalFleetAirplanes.head
+    val invalidFleetAirplanes = List(
+      existingFleetAirplane.copy(fleetId = idNotPresent),
+      existingFleetAirplane.copy(airplaneId = idNotPresent)
+    )
+
+    forAll(invalidFleetAirplanes) { fleetAirplane =>
+      repo
+        .updateFleetAirplane(fleetAirplane)
+        .error shouldBe EntryHasInvalidForeignKey
+    }
+  }
+
+  it should "not work if the fleet-airplane combination already exists" in {
+    val existingFleetAirplaneId = originalFleetAirplanes.head.id
+    repo
+      .updateFleetAirplane(FleetAirplane.fromCreate(existingFleetAirplaneId, newFleetAirplane))
+      .error shouldBe EntryAlreadyExists
+  }
+
+  it should "work if all criteria are met" in {
+    val existingFleetAirplane = repo
+      .getFleetAirplane(newFleetAirplane.fleetId, newFleetAirplane.airplaneId)
+      .value
+
+    val updated = existingFleetAirplane.copy(airplaneId = updatedAirplane)
+    repo.updateFleetAirplane(updated).value shouldBe updated.id
+
+    val updatedFleetAirplane = repo.getFleetAirplane(updated.id).value
+    updatedFleetAirplane shouldBe updated
+  }
+
+  "Patching a fleet airplane" should "not work if the fleet or airplane does not exist" in {
+    val existingFleetAirplaneId = originalFleetAirplanes.head.id
+
+    val invalidFleetAirplanes = List(
+      FleetAirplanePatch(fleetId = Some(veryLongIdNotPresent)),
+      FleetAirplanePatch(airplaneId = Some(idNotPresent))
+    )
+
+    forAll(invalidFleetAirplanes) { patch =>
+      repo
+        .partiallyUpdateFleetAirplane(existingFleetAirplaneId, patch)
+        .error shouldBe EntryHasInvalidForeignKey
+    }
+  }
+
+  it should "not work if we patch a non-existing fleet-airplane entry" in {
+    val patched = FleetAirplanePatch(fleetId = Some(1))
+    repo
+      .partiallyUpdateFleetAirplane(idNotPresent, patched)
+      .error shouldBe EntryNotFound(idNotPresent)
+  }
+
+  it should "not work if the fleet-airplane combination already exists" in {
+    val existingFleetAirplane = originalFleetAirplanes.find(_.fleetId == newFleetAirplane.fleetId)
+
+    existingFleetAirplane.foreach { fa =>
+      val patched = FleetAirplanePatch(airplaneId = Some(updatedAirplane))
+      repo
+        .partiallyUpdateFleetAirplane(fa.id, patched)
+        .error shouldBe EntryAlreadyExists
+    }
+  }
+
+  it should "work if all criteria are met" in {
+    val existingFleetAirplane = repo
+      .getFleetAirplane(newFleetAirplane.fleetId, updatedAirplane)
+      .value
+
+    val patched = FleetAirplanePatch(airplaneId = Some(patchedAirplane))
+    val patchedFleetAirplane = repo
+      .partiallyUpdateFleetAirplane(existingFleetAirplane.id, patched)
+      .value
+
+    patchedFleetAirplane shouldBe existingFleetAirplane.copy(airplaneId = patchedAirplane)
+  }
+
+  "Removing a fleet-airplane" should "work correctly if it exists" in {
+    val existingFleetAirplane = repo
+      .getFleetAirplane(newFleetAirplane.fleetId, patchedAirplane)
+      .value
+
+    repo
+      .removeFleetAirplane(existingFleetAirplane.id)
+      .value shouldBe ()
+
+    repo
+      .getFleetAirplane(existingFleetAirplane.id)
+      .error shouldBe EntryNotFound(existingFleetAirplane.id)
+  }
+
+  "Removing a fleet-airplane" should "not work if the fleet-airplane does not exist" in {
+    repo
+      .removeFleetAirplane(idNotPresent)
+      .error shouldBe EntryNotFound(idNotPresent)
   }
 }

--- a/src/it/scala/flightdatabase/repository/FleetRouteRepositoryIT.scala
+++ b/src/it/scala/flightdatabase/repository/FleetRouteRepositoryIT.scala
@@ -5,7 +5,7 @@ import cats.effect.unsafe.implicits.global
 import flightdatabase.domain.fleet_route.FleetRoute
 import flightdatabase.testutils.RepositoryCheck
 
-class FleetRouteRepositoryIT extends RepositoryCheck {
+final class FleetRouteRepositoryIT extends RepositoryCheck {
 
   "Selecting all fleet routes" should "return the correct detailed list" in {
     val fleetRoutes = {

--- a/src/it/scala/flightdatabase/repository/GenericRepositoryIT.scala
+++ b/src/it/scala/flightdatabase/repository/GenericRepositoryIT.scala
@@ -37,13 +37,11 @@ final class GenericRepositoryIT extends RepositoryCheck {
   }
 
   "Selecting all city names in Brazil" should "return an empty list" in {
-    val cityNames =
-      getFieldList[City, String, Country, String]("name", FieldValue("name", "Brazil")).execute
-        .unsafeRunSync()
-        .left
-        .value
-
-    cityNames shouldBe EntryNotFound("country.name = Brazil")
+    val fieldValueBrazil = FieldValue[Country, String]("name", "Brazil")
+    getFieldList[City, String, Country, String]("name", fieldValueBrazil).execute
+      .unsafeRunSync()
+      .left
+      .value shouldBe EntryNotFound(fieldValueBrazil)
   }
 
 }

--- a/src/it/scala/flightdatabase/repository/LanguageRepositoryIT.scala
+++ b/src/it/scala/flightdatabase/repository/LanguageRepositoryIT.scala
@@ -5,7 +5,7 @@ import cats.effect.unsafe.implicits.global
 import flightdatabase.domain.language.Language
 import flightdatabase.testutils.RepositoryCheck
 
-class LanguageRepositoryIT extends RepositoryCheck {
+final class LanguageRepositoryIT extends RepositoryCheck {
 
   "Selecting all languages" should "return the correct detailed list" in {
     val languages = {

--- a/src/it/scala/flightdatabase/repository/LanguageRepositoryIT.scala
+++ b/src/it/scala/flightdatabase/repository/LanguageRepositoryIT.scala
@@ -2,28 +2,289 @@ package flightdatabase.repository
 
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
+import flightdatabase.domain.ApiResult
+import flightdatabase.domain.EntryAlreadyExists
+import flightdatabase.domain.EntryCheckFailed
+import flightdatabase.domain.EntryListEmpty
+import flightdatabase.domain.EntryNotFound
+import flightdatabase.domain.UnknownDbError
 import flightdatabase.domain.language.Language
+import flightdatabase.domain.language.LanguageCreate
+import flightdatabase.domain.language.LanguagePatch
 import flightdatabase.testutils.RepositoryCheck
+import org.scalatest.Inspectors.forAll
 
 final class LanguageRepositoryIT extends RepositoryCheck {
 
+  lazy val repo: LanguageRepository[IO] = LanguageRepository.make[IO].unsafeRunSync()
+
+  val originalLanguages: List[Language] = List(
+    Language(1, "English", "EN", Some("ENG"), "English"),
+    Language(2, "German", "DE", Some("DEU"), "Deutsch"),
+    Language(3, "Tamil", "TA", Some("TAM"), "Tamil"),
+    Language(4, "Swedish", "SV", Some("SWE"), "Svenska"),
+    Language(5, "Arabic", "AR", Some("ARA"), "Al-Arabiyyah"),
+    Language(6, "Dutch", "NL", Some("NLD"), "Nederlands"),
+    Language(7, "Hindi", "HI", Some("HIN"), "Hindi")
+  )
+
+  val idNotPresent: Long = 100
+  val valueNotPresent: String = "Not present"
+  val veryLongIdNotPresent: Long = 1000000000000000000L
+  val stringTooLongSqlState: String = "22001"
+
+  val newLanguage: LanguageCreate =
+    LanguageCreate("New Language", "NA", Some("NLA"), "New Language")
+  val updatedName: String = "Updated Language"
+  val patchedName: String = "Patched Language"
+
+  "Checking if a language exists" should "return a valid result" in {
+    def languageExists(id: Long): Boolean = repo.doesLanguageExist(id).unsafeRunSync()
+    languageExists(1) shouldBe true
+    languageExists(idNotPresent) shouldBe false
+    languageExists(veryLongIdNotPresent) shouldBe false
+  }
+
   "Selecting all languages" should "return the correct detailed list" in {
-    val languages = {
-      for {
-        repo         <- LanguageRepository.make[IO]
-        allLanguages <- repo.getLanguages
-      } yield allLanguages
-    }.unsafeRunSync().value.value
+    val languages = repo.getLanguages.unsafeRunSync().value.value
 
     languages should not be empty
-    languages should contain only (
-      Language(1, "English", "EN", Some("ENG"), "English"),
-      Language(2, "German", "DE", Some("DEU"), "Deutsch"),
-      Language(3, "Tamil", "TA", Some("TAM"), "Tamil"),
-      Language(4, "Swedish", "SV", Some("SWE"), "Svenska"),
-      Language(5, "Arabic", "AR", Some("ARA"), "Al-Arabiyyah"),
-      Language(6, "Dutch", "NL", Some("NLD"), "Nederlands"),
-      Language(7, "Hindi", "HI", Some("HIN"), "Hindi")
+    languages should contain only (originalLanguages: _*)
+  }
+
+  it should "only return names if so required" in {
+    val languageNames = repo.getLanguagesOnlyNames.unsafeRunSync().value.value
+
+    languageNames should not be empty
+    languageNames should contain only (originalLanguages.map(_.name): _*)
+  }
+
+  "Selecting a language by ID" should "return the correct language" in {
+    def languageById(id: Long): ApiResult[Language] = repo.getLanguage(id).unsafeRunSync()
+
+    forAll(originalLanguages) { language =>
+      languageById(language.id).value.value shouldBe language
+    }
+    languageById(idNotPresent).left.value shouldBe EntryNotFound(idNotPresent)
+    languageById(veryLongIdNotPresent).left.value shouldBe EntryNotFound(veryLongIdNotPresent)
+  }
+
+  "Selecting a language by other fields" should "return the corresponding entries" in {
+    def languageByName(name: String): ApiResult[List[Language]] =
+      repo.getLanguages("name", name).unsafeRunSync()
+
+    def languageByIso2(iso2: String): ApiResult[List[Language]] =
+      repo.getLanguages("iso2", iso2).unsafeRunSync()
+
+    def languageByIso3(iso3: String): ApiResult[List[Language]] =
+      repo.getLanguages("iso3", iso3).unsafeRunSync()
+
+    def languageByOriginalName(originalName: String): ApiResult[List[Language]] =
+      repo.getLanguages("original_name", originalName).unsafeRunSync()
+
+    forAll(originalLanguages) { language =>
+      languageByName(language.name).value.value should contain only language
+      languageByIso2(language.iso2).value.value should contain only language
+      language.iso3.foreach { iso3 =>
+        languageByIso3(iso3).value.value should contain only language
+      }
+      languageByOriginalName(language.originalName).value.value should contain(language)
+    }
+
+    languageByName(valueNotPresent).left.value shouldBe EntryListEmpty
+    languageByIso2(valueNotPresent).left.value shouldBe EntryListEmpty
+    languageByIso3(valueNotPresent).left.value shouldBe EntryListEmpty
+    languageByOriginalName(valueNotPresent).left.value shouldBe EntryListEmpty
+  }
+
+  "Creating a new language" should "not take place if fields do not satisfy their criteria" in {
+    val invalidLanguages = List(
+      newLanguage.copy(name = ""),
+      newLanguage.copy(iso2 = ""),
+      newLanguage.copy(iso3 = Some("")),
+      newLanguage.copy(originalName = "")
     )
+
+    forAll(invalidLanguages) { language =>
+      repo.createLanguage(language).unsafeRunSync().left.value shouldBe EntryCheckFailed
+    }
+
+    val invalidLanguages2 = List(
+      newLanguage.copy(iso2 = "ENG"),          // Must be 2 characters
+      newLanguage.copy(iso3 = Some("ENGLISH")) // Must be 3 characters
+    )
+
+    forAll(invalidLanguages2) { language =>
+      repo.createLanguage(language).unsafeRunSync().left.value shouldBe UnknownDbError(
+        stringTooLongSqlState
+      )
+    }
+  }
+
+  it should "not take place for a language with existing unique fields" in {
+    val existingLanguage = originalLanguages.head
+
+    val duplicateLanguages = List(
+      newLanguage.copy(iso2 = existingLanguage.iso2),
+      newLanguage.copy(iso3 = existingLanguage.iso3)
+    )
+
+    forAll(duplicateLanguages) { language =>
+      repo.createLanguage(language).unsafeRunSync().left.value shouldBe EntryAlreadyExists
+    }
+  }
+
+  it should "work if all criteria are met" in {
+    val newLanguageId = repo.createLanguage(newLanguage).unsafeRunSync().value.value
+    val newLanguageFromDb = repo.getLanguage(newLanguageId).unsafeRunSync().value.value
+
+    newLanguageFromDb shouldBe Language.fromCreate(newLanguageId, newLanguage)
+  }
+
+  it should "throw a conflict error if we create the same language again" in {
+    repo.createLanguage(newLanguage).unsafeRunSync().left.value shouldBe EntryAlreadyExists
+  }
+
+  "Updating a language" should "not take place if fields do not satisfy their criteria" in {
+    val existingLanguage = originalLanguages.head
+
+    val invalidLanguages = List(
+      existingLanguage.copy(name = ""),
+      existingLanguage.copy(iso2 = ""),
+      existingLanguage.copy(iso3 = Some("")),
+      existingLanguage.copy(originalName = "")
+    )
+
+    forAll(invalidLanguages) { language =>
+      repo.updateLanguage(language).unsafeRunSync().left.value shouldBe EntryCheckFailed
+    }
+
+    val invalidLanguages2 = List(
+      existingLanguage.copy(iso2 = "ENG"),          // Must be 2 characters
+      existingLanguage.copy(iso3 = Some("ENGLISH")) // Must be 3 characters
+    )
+
+    forAll(invalidLanguages2) { language =>
+      repo.updateLanguage(language).unsafeRunSync().left.value shouldBe UnknownDbError(
+        stringTooLongSqlState
+      )
+    }
+  }
+
+  it should "not take place for a language with existing unique fields" in {
+    val existingLanguage = originalLanguages.head
+
+    val duplicateLanguages = List(
+      existingLanguage.copy(iso2 = newLanguage.iso2),
+      existingLanguage.copy(iso3 = newLanguage.iso3)
+    )
+
+    forAll(duplicateLanguages) { language =>
+      repo.updateLanguage(language).unsafeRunSync().left.value shouldBe EntryAlreadyExists
+    }
+  }
+
+  it should "throw an error if we update a language that does not exist" in {
+    val updated = Language.fromCreate(idNotPresent, newLanguage)
+    repo.updateLanguage(updated).unsafeRunSync().left.value shouldBe EntryNotFound(idNotPresent)
+  }
+
+  it should "work if all criteria are met" in {
+    val existingLanguage =
+      repo.getLanguages("name", newLanguage.name).unsafeRunSync().value.value.head
+    val updated = existingLanguage.copy(name = updatedName)
+    repo.updateLanguage(updated).unsafeRunSync().value.value shouldBe existingLanguage.id
+
+    val updatedLanguageFromDb = repo.getLanguage(existingLanguage.id).unsafeRunSync().value.value
+    updatedLanguageFromDb shouldBe updated
+  }
+
+  "Patching a language" should "not take place if fields do not satisfy their criteria" in {
+    val existingLanguage = originalLanguages.head
+
+    val invalidLanguages = List(
+      LanguagePatch(name = Some("")),
+      LanguagePatch(iso2 = Some("")),
+      LanguagePatch(iso3 = Some("")),
+      LanguagePatch(originalName = Some(""))
+    )
+
+    forAll(invalidLanguages) { language =>
+      repo
+        .partiallyUpdateLanguage(existingLanguage.id, language)
+        .unsafeRunSync()
+        .left
+        .value shouldBe EntryCheckFailed
+    }
+
+    val invalidLanguages2 = List(
+      LanguagePatch(iso2 = Some("ENG")),    // Must be 2 characters
+      LanguagePatch(iso3 = Some("ENGLISH")) // Must be 3 characters
+    )
+
+    forAll(invalidLanguages2) { language =>
+      repo
+        .partiallyUpdateLanguage(existingLanguage.id, language)
+        .unsafeRunSync()
+        .left
+        .value shouldBe UnknownDbError(stringTooLongSqlState)
+    }
+  }
+
+  it should "not take place for a language with existing unique fields" in {
+    val existingLanguage = originalLanguages.head
+
+    val duplicateLanguages = List(
+      LanguagePatch(iso2 = Some(newLanguage.iso2)),
+      LanguagePatch(iso3 = newLanguage.iso3)
+    )
+
+    forAll(duplicateLanguages) { language =>
+      repo
+        .partiallyUpdateLanguage(existingLanguage.id, language)
+        .unsafeRunSync()
+        .left
+        .value shouldBe EntryAlreadyExists
+    }
+  }
+
+  it should "throw an error if we patch a language that does not exist" in {
+    val patched = LanguagePatch(name = Some(patchedName))
+    repo
+      .partiallyUpdateLanguage(idNotPresent, patched)
+      .unsafeRunSync()
+      .left
+      .value shouldBe EntryNotFound(idNotPresent)
+  }
+
+  it should "work if all criteria are met" in {
+    val existingLanguage = repo.getLanguages("name", updatedName).unsafeRunSync().value.value.head
+    val patched = LanguagePatch(name = Some(patchedName))
+
+    repo
+      .partiallyUpdateLanguage(existingLanguage.id, patched)
+      .unsafeRunSync()
+      .value
+      .value shouldBe existingLanguage.copy(name = patchedName)
+
+    val patchedLanguageFromDb = repo.getLanguage(existingLanguage.id).unsafeRunSync().value.value
+    patchedLanguageFromDb shouldBe existingLanguage.copy(name = patchedName)
+  }
+
+  "Removing a language" should "work correctly" in {
+    val existingLanguage = repo.getLanguages("name", patchedName).unsafeRunSync().value.value.head
+    repo.removeLanguage(existingLanguage.id).unsafeRunSync().value.value shouldBe ()
+
+    repo.getLanguage(existingLanguage.id).unsafeRunSync().left.value shouldBe EntryNotFound(
+      existingLanguage.id
+    )
+  }
+
+  it should "not work if the language does not exist" in {
+    repo
+      .removeLanguage(idNotPresent)
+      .unsafeRunSync()
+      .left
+      .value shouldBe EntryNotFound(idNotPresent)
   }
 }

--- a/src/it/scala/flightdatabase/repository/ManufacturerRepositoryIT.scala
+++ b/src/it/scala/flightdatabase/repository/ManufacturerRepositoryIT.scala
@@ -5,7 +5,7 @@ import cats.effect.unsafe.implicits.global
 import flightdatabase.domain.manufacturer.Manufacturer
 import flightdatabase.testutils.RepositoryCheck
 
-class ManufacturerRepositoryIT extends RepositoryCheck {
+final class ManufacturerRepositoryIT extends RepositoryCheck {
 
   "Selecting all manufacturers" should "return the correct detailed list" in {
     val manufacturers = {

--- a/src/it/scala/flightdatabase/repository/ManufacturerRepositoryIT.scala
+++ b/src/it/scala/flightdatabase/repository/ManufacturerRepositoryIT.scala
@@ -2,23 +2,210 @@ package flightdatabase.repository
 
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
+import flightdatabase.domain.ApiError
+import flightdatabase.domain.ApiResult
+import flightdatabase.domain.EntryAlreadyExists
+import flightdatabase.domain.EntryCheckFailed
+import flightdatabase.domain.EntryHasInvalidForeignKey
+import flightdatabase.domain.EntryListEmpty
+import flightdatabase.domain.EntryNotFound
+import flightdatabase.domain.country.Country
 import flightdatabase.domain.manufacturer.Manufacturer
+import flightdatabase.domain.manufacturer.ManufacturerCreate
+import flightdatabase.domain.manufacturer.ManufacturerPatch
 import flightdatabase.testutils.RepositoryCheck
+import flightdatabase.testutils.implicits.enrichIOOperation
+import flightdatabase.utils.FieldValue
+import org.scalatest.Inspectors.forAll
 
 final class ManufacturerRepositoryIT extends RepositoryCheck {
 
+  lazy val repo: ManufacturerRepository[IO] = ManufacturerRepository.make[IO].unsafeRunSync()
+
+  val originalManufacturers: List[Manufacturer] = List(
+    Manufacturer(1, "Airbus", 5),
+    Manufacturer(2, "Boeing", 6)
+  )
+
+  val idNotPresent: Long = 100
+  val valueNotPresent: String = "NotPresent"
+  val veryLongIdNotPresent: Long = 1039495454540034858L
+
+  val cityIdMap: Map[Long, String] = Map(5L -> "Leiden", 6L -> "Chicago")
+
+  val cityIdCountryMap: Map[Long, String] =
+    Map(5L -> "Netherlands", 6L -> "United States of America")
+
+  val newManufacturer: ManufacturerCreate = ManufacturerCreate("ADA", 1)
+  val updatedName: String = "Aeronautical Agency"
+  val patchedName: String = "Aeronautical Development Agency"
+
+  "Checking if a manufacturer exists" should "return a valid result" in {
+    def manufacturerExists(id: Long): Boolean = repo.doesManufacturerExist(id).unsafeRunSync()
+    forAll(originalManufacturers)(m => manufacturerExists(m.id) shouldBe true)
+    manufacturerExists(idNotPresent) shouldBe false
+    manufacturerExists(veryLongIdNotPresent) shouldBe false
+  }
+
   "Selecting all manufacturers" should "return the correct detailed list" in {
-    val manufacturers = {
-      for {
-        repo             <- ManufacturerRepository.make[IO]
-        allManufacturers <- repo.getManufacturers
-      } yield allManufacturers
-    }.unsafeRunSync().value.value
+    val manufacturers = repo.getManufacturers.value
 
     manufacturers should not be empty
-    manufacturers should contain only (
-      Manufacturer(1, "Airbus", 5),
-      Manufacturer(2, "Boeing", 6)
+    manufacturers should contain only (originalManufacturers: _*)
+  }
+
+  it should "return only names if so required" in {
+    val manufacturers = repo.getManufacturersOnlyNames.value
+
+    manufacturers should not be empty
+    manufacturers should contain only (originalManufacturers.map(_.name): _*)
+  }
+
+  "Selecting a manufacturer by ID" should "return the correct manufacturer" in {
+    forAll(originalManufacturers)(m => repo.getManufacturer(m.id).value shouldBe m)
+    repo.getManufacturer(idNotPresent).error shouldBe EntryNotFound(idNotPresent)
+    repo.getManufacturer(veryLongIdNotPresent).error shouldBe EntryNotFound(veryLongIdNotPresent)
+  }
+
+  "Selecting a manufacturer by other fields" should "return the correct manufacturer(s)" in {
+    def manufacturerByName(name: String): IO[ApiResult[List[Manufacturer]]] =
+      repo.getManufacturers("name", name)
+
+    def manufacturerByCity(cityId: Long): IO[ApiResult[List[Manufacturer]]] =
+      repo.getManufacturers("city_based_in", cityId)
+
+    val distinctCityIds = originalManufacturers.map(_.cityBasedIn).distinct
+
+    forAll(originalManufacturers)(m => manufacturerByName(m.name).value should contain only m)
+    forAll(distinctCityIds) { cityId =>
+      manufacturerByCity(cityId).value should contain only (
+        originalManufacturers.filter(_.cityBasedIn == cityId): _*
+      )
+    }
+    manufacturerByName(valueNotPresent).error shouldBe EntryListEmpty
+  }
+
+  "Selecting a manufacturer by city/country name" should "return the correct list of manufacturers" in {
+    def manufacturerByCity(city: String): IO[ApiResult[List[Manufacturer]]] =
+      repo.getManufacturersByCity(city)
+
+    def manufacturerByCountry(country: String): IO[ApiResult[List[Manufacturer]]] =
+      repo.getManufacturersByCountry(country)
+
+    forAll(cityIdMap) {
+      case (cityId, cityName) =>
+        manufacturerByCity(cityName).value should contain only (
+          originalManufacturers.filter(_.cityBasedIn == cityId): _*
+        )
+    }
+
+    forAll(cityIdCountryMap) {
+      case (cityId, countryName) =>
+        manufacturerByCountry(countryName).value should contain only (
+          originalManufacturers.filter(_.cityBasedIn == cityId): _*
+        )
+    }
+
+    manufacturerByCity(valueNotPresent).error shouldBe EntryListEmpty
+
+    val fv = FieldValue[Country, String]("name", valueNotPresent)
+    manufacturerByCountry(valueNotPresent).error shouldBe EntryNotFound(fv)
+  }
+
+  "Creating a new manufacturer" should "not take place if fields do not satisfy their criteria" in {
+    val manufacturerWithInvalidName = newManufacturer.copy(name = "")
+    repo.createManufacturer(manufacturerWithInvalidName).error shouldBe EntryCheckFailed
+
+    val manufacturerWithNonUniqueName = newManufacturer.copy(name = originalManufacturers.head.name)
+    repo.createManufacturer(manufacturerWithNonUniqueName).error shouldBe EntryAlreadyExists
+
+    val manufacturerWithNonExistingCity = newManufacturer.copy(cityBasedIn = idNotPresent)
+    repo
+      .createManufacturer(manufacturerWithNonExistingCity)
+      .error shouldBe EntryHasInvalidForeignKey
+  }
+
+  it should "take place if all fields satisfy their criteria" in {
+    val newId = repo.createManufacturer(newManufacturer).value
+    val newManufacturerFromDb = repo.getManufacturer(newId).value
+    newManufacturerFromDb shouldBe Manufacturer.fromCreate(newId, newManufacturer)
+  }
+
+  it should "throw a conflict error if the manufacturer already exists" in {
+    repo.createManufacturer(newManufacturer).error shouldBe EntryAlreadyExists
+  }
+
+  "Updating a manufacturer" should "not take place if fields do not satisfy their criteria" in {
+    val existingManufacturer = originalManufacturers.head
+
+    val manufacturerWithInvalidName = existingManufacturer.copy(name = "")
+    repo.updateManufacturer(manufacturerWithInvalidName).error shouldBe EntryCheckFailed
+
+    val manufacturerWithNonUniqueName = existingManufacturer.copy(name = newManufacturer.name)
+    repo.updateManufacturer(manufacturerWithNonUniqueName).error shouldBe EntryAlreadyExists
+
+    val manufacturerWithNonExistingCity = existingManufacturer.copy(cityBasedIn = idNotPresent)
+    repo
+      .updateManufacturer(manufacturerWithNonExistingCity)
+      .error shouldBe EntryHasInvalidForeignKey
+  }
+
+  it should "not work for a non-existing manufacturer" in {
+    val updated = Manufacturer.fromCreate(idNotPresent, newManufacturer)
+    repo.updateManufacturer(updated).error shouldBe EntryNotFound(idNotPresent)
+  }
+
+  it should "work if all criteria are met" in {
+    val existingManufacturer = repo.getManufacturers("name", newManufacturer.name).value.head
+
+    val updated = existingManufacturer.copy(name = updatedName)
+    repo.updateManufacturer(updated).value shouldBe existingManufacturer.id
+
+    val updatedManufacturer = repo.getManufacturer(existingManufacturer.id).value
+    updatedManufacturer shouldBe updated
+  }
+
+  "Patching a manufacturer" should "not take place if fields do not satisfy their criteria" in {
+    val existingManufacturer = originalManufacturers.head
+    def patchManufacturer(patch: ManufacturerPatch): ApiError =
+      repo.partiallyUpdateManufacturer(existingManufacturer.id, patch).error
+
+    val manufacturerWithInvalidName = ManufacturerPatch(name = Some(""))
+    patchManufacturer(manufacturerWithInvalidName) shouldBe EntryCheckFailed
+
+    val manufacturerWithNonUniqueName = ManufacturerPatch(name = Some(updatedName))
+    patchManufacturer(manufacturerWithNonUniqueName) shouldBe EntryAlreadyExists
+
+    val manufacturerWithNonExistingCity = ManufacturerPatch(cityBasedIn = Some(idNotPresent))
+    patchManufacturer(manufacturerWithNonExistingCity) shouldBe EntryHasInvalidForeignKey
+  }
+
+  it should "not work for a non-existing manufacturer" in {
+    val patched = ManufacturerPatch(name = Some(patchedName))
+    repo.partiallyUpdateManufacturer(idNotPresent, patched).error shouldBe EntryNotFound(
+      idNotPresent
     )
+  }
+
+  it should "work if all criteria are met" in {
+    val existingManufacturer = repo.getManufacturers("name", updatedName).value.head
+
+    val patch = ManufacturerPatch(name = Some(patchedName))
+    val patched = existingManufacturer.copy(name = patchedName)
+    repo.partiallyUpdateManufacturer(existingManufacturer.id, patch).value shouldBe patched
+
+    repo.getManufacturer(existingManufacturer.id).value shouldBe patched
+  }
+
+  "Removing a manufacturer" should "work correctly" in {
+    val existingManufacturer = repo.getManufacturers("name", patchedName).value.head
+    repo.removeManufacturer(existingManufacturer.id).value shouldBe ()
+    repo.getManufacturer(existingManufacturer.id).error shouldBe EntryNotFound(
+      existingManufacturer.id
+    )
+  }
+
+  it should "not work for a non-existing manufacturer" in {
+    repo.removeManufacturer(idNotPresent).error shouldBe EntryNotFound(idNotPresent)
   }
 }

--- a/src/it/scala/flightdatabase/testutils/implicits/RichIOOperation.scala
+++ b/src/it/scala/flightdatabase/testutils/implicits/RichIOOperation.scala
@@ -1,0 +1,12 @@
+package flightdatabase.testutils.implicits
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import flightdatabase.domain.ApiError
+import flightdatabase.domain.ApiResult
+import org.scalatest.EitherValues._
+
+class RichIOOperation[A](private val op: IO[ApiResult[A]]) extends AnyVal {
+  def value: A = op.unsafeRunSync().value.value
+  def error: ApiError = op.unsafeRunSync().left.value
+}

--- a/src/it/scala/flightdatabase/testutils/implicits/package.scala
+++ b/src/it/scala/flightdatabase/testutils/implicits/package.scala
@@ -1,0 +1,10 @@
+package flightdatabase.testutils
+
+import cats.effect.IO
+import flightdatabase.domain.ApiResult
+
+package object implicits {
+
+  @inline implicit def enrichIOOperation[A](op: IO[ApiResult[A]]): RichIOOperation[A] =
+    new RichIOOperation(op)
+}

--- a/src/main/resources/db/migration/V3__create_indices.sql
+++ b/src/main/resources/db/migration/V3__create_indices.sql
@@ -7,6 +7,7 @@ ALTER TABLE currency ADD UNIQUE (iso);
 ALTER TABLE currency ADD UNIQUE NULLS NOT DISTINCT (symbol);
 
 -- Unique indices on country
+ALTER TABLE country ADD UNIQUE (name);
 ALTER TABLE country ADD UNIQUE (iso2);
 ALTER TABLE country ADD UNIQUE (iso3);
 ALTER TABLE country ADD UNIQUE (country_code);

--- a/src/main/scala/flightdatabase/api/endpoints/AirplaneEndpoints.scala
+++ b/src/main/scala/flightdatabase/api/endpoints/AirplaneEndpoints.scala
@@ -68,11 +68,11 @@ class AirplaneEndpoints[F[_]: Concurrent] private (prefix: String, algebra: Airp
       } { id =>
         req
           .attemptAs[Airplane]
-          .foldF[ApiResult[Airplane]](
-            _ => EntryInvalidFormat.elevate[F, Airplane],
+          .foldF[ApiResult[Long]](
+            _ => EntryInvalidFormat.elevate[F, Long],
             airplane =>
               if (id != airplane.id) {
-                InconsistentIds(id, airplane.id).elevate[F, Airplane]
+                InconsistentIds(id, airplane.id).elevate[F, Long]
               } else {
                 algebra.updateAirplane(airplane)
               }

--- a/src/main/scala/flightdatabase/api/endpoints/AirportEndpoints.scala
+++ b/src/main/scala/flightdatabase/api/endpoints/AirportEndpoints.scala
@@ -41,11 +41,11 @@ class AirportEndpoints[F[_]: Concurrent] private (prefix: String, algebra: Airpo
 
     // GET /airports/iata/{iata}
     case GET -> Root / "iata" / iata =>
-      algebra.getAirportsBy("iata", iata).flatMap(toResponse(_))
+      algebra.getAirports("iata", iata).flatMap(toResponse(_))
 
     // GET /airports/icao/{icao}
     case GET -> Root / "icao" / icao =>
-      algebra.getAirportsBy("icao", icao).flatMap(toResponse(_))
+      algebra.getAirports("icao", icao).flatMap(toResponse(_))
 
     // GET /airports/city/{city_name} OR
     // GET /airports/city/{city_id}
@@ -53,7 +53,7 @@ class AirportEndpoints[F[_]: Concurrent] private (prefix: String, algebra: Airpo
       city.asLong.fold[F[Response[F]]] {
         // Treat city as name
         algebra.getAirportsByCity(city).flatMap(toResponse(_))
-      }(algebra.getAirportsBy("city_id", _).flatMap(toResponse(_)))
+      }(algebra.getAirports("city_id", _).flatMap(toResponse(_)))
 
     // GET /airports/country/{country}
     case GET -> Root / "country" / country =>
@@ -76,11 +76,11 @@ class AirportEndpoints[F[_]: Concurrent] private (prefix: String, algebra: Airpo
       } { id =>
         req
           .attemptAs[Airport]
-          .foldF[ApiResult[Airport]](
-            _ => EntryInvalidFormat.elevate[F, Airport],
+          .foldF[ApiResult[Long]](
+            _ => EntryInvalidFormat.elevate[F, Long],
             airport =>
               if (id != airport.id) {
-                InconsistentIds(id, airport.id).elevate[F, Airport]
+                InconsistentIds(id, airport.id).elevate[F, Long]
               } else {
                 algebra.updateAirport(airport)
               }

--- a/src/main/scala/flightdatabase/api/endpoints/CityEndpoints.scala
+++ b/src/main/scala/flightdatabase/api/endpoints/CityEndpoints.scala
@@ -69,11 +69,11 @@ class CityEndpoints[F[_]: Concurrent] private (prefix: String, algebra: CityAlge
       } { id =>
         req
           .attemptAs[City]
-          .foldF[ApiResult[City]](
-            _ => EntryInvalidFormat.elevate[F, City],
+          .foldF[ApiResult[Long]](
+            _ => EntryInvalidFormat.elevate[F, Long],
             city =>
               if (id != city.id) {
-                InconsistentIds(id, city.id).elevate[F, City]
+                InconsistentIds(id, city.id).elevate[F, Long]
               } else {
                 algebra.updateCity(city)
               }

--- a/src/main/scala/flightdatabase/api/endpoints/CountryEndpoints.scala
+++ b/src/main/scala/flightdatabase/api/endpoints/CountryEndpoints.scala
@@ -61,11 +61,11 @@ class CountryEndpoints[F[_]: Concurrent] private (prefix: String, algebra: Count
       } { id =>
         req
           .attemptAs[Country]
-          .foldF[ApiResult[Country]](
-            _ => EntryInvalidFormat.elevate[F, Country],
+          .foldF[ApiResult[Long]](
+            _ => EntryInvalidFormat.elevate[F, Long],
             country =>
               if (id != country.id) {
-                InconsistentIds(id, country.id).elevate[F, Country]
+                InconsistentIds(id, country.id).elevate[F, Long]
               } else {
                 algebra.updateCountry(country)
               }

--- a/src/main/scala/flightdatabase/api/endpoints/CurrencyEndpoints.scala
+++ b/src/main/scala/flightdatabase/api/endpoints/CurrencyEndpoints.scala
@@ -65,11 +65,11 @@ class CurrencyEndpoints[F[_]: Concurrent] private (prefix: String, algebra: Curr
       } { id =>
         req
           .attemptAs[Currency]
-          .foldF[ApiResult[Currency]](
-            _ => EntryInvalidFormat.elevate[F, Currency],
+          .foldF[ApiResult[Long]](
+            _ => EntryInvalidFormat.elevate[F, Long],
             currency =>
               if (id != currency.id) {
-                InconsistentIds(id, currency.id).elevate[F, Currency]
+                InconsistentIds(id, currency.id).elevate[F, Long]
               } else {
                 algebra.updateCurrency(currency)
               }

--- a/src/main/scala/flightdatabase/api/endpoints/FleetAirplaneEndpoints.scala
+++ b/src/main/scala/flightdatabase/api/endpoints/FleetAirplaneEndpoints.scala
@@ -39,6 +39,15 @@ class FleetAirplaneEndpoints[F[_]: Concurrent] private (
         BadRequest(EntryInvalidFormat.error)
       }(id => algebra.getFleetAirplane(id).flatMap(toResponse(_)))
 
+    // GET /fleet-airplanes/fleet/{fleet_id}/airplane/{airplane_id}
+    case GET -> Root / "fleet" / fleetId / "airplane" / airplaneId =>
+      (fleetId.asLong, airplaneId.asLong).tupled.fold {
+        BadRequest(EntryInvalidFormat.error)
+      } {
+        case (fId, aId) =>
+          algebra.getFleetAirplane(fId, aId).flatMap(toResponse(_))
+      }
+
     // GET /fleet-airplanes/airplane/{airplane_id} OR
     // GET /fleet-airplanes/airplane/{airplane_name}
     case GET -> Root / "airplane" / airplane => {

--- a/src/main/scala/flightdatabase/api/endpoints/FleetAirplaneEndpoints.scala
+++ b/src/main/scala/flightdatabase/api/endpoints/FleetAirplaneEndpoints.scala
@@ -80,11 +80,11 @@ class FleetAirplaneEndpoints[F[_]: Concurrent] private (
       } { id =>
         req
           .attemptAs[FleetAirplane]
-          .foldF[ApiResult[FleetAirplane]](
-            _ => EntryInvalidFormat.elevate[F, FleetAirplane],
+          .foldF[ApiResult[Long]](
+            _ => EntryInvalidFormat.elevate[F, Long],
             fa =>
               if (id != fa.id) {
-                InconsistentIds(id, fa.id).elevate[F, FleetAirplane]
+                InconsistentIds(id, fa.id).elevate[F, Long]
               } else {
                 algebra.updateFleetAirplane(fa)
               }

--- a/src/main/scala/flightdatabase/api/endpoints/FleetEndpoints.scala
+++ b/src/main/scala/flightdatabase/api/endpoints/FleetEndpoints.scala
@@ -76,11 +76,11 @@ class FleetEndpoints[F[_]: Concurrent] private (prefix: String, algebra: FleetAl
       } { id =>
         req
           .attemptAs[Fleet]
-          .foldF[ApiResult[Fleet]](
-            _ => EntryInvalidFormat.elevate[F, Fleet],
+          .foldF[ApiResult[Long]](
+            _ => EntryInvalidFormat.elevate[F, Long],
             fleet =>
               if (id != fleet.id) {
-                InconsistentIds(id, fleet.id).elevate[F, Fleet]
+                InconsistentIds(id, fleet.id).elevate[F, Long]
               } else {
                 algebra.updateFleet(fleet)
               }

--- a/src/main/scala/flightdatabase/api/endpoints/FleetRouteEndpoints.scala
+++ b/src/main/scala/flightdatabase/api/endpoints/FleetRouteEndpoints.scala
@@ -104,11 +104,11 @@ class FleetRouteEndpoints[F[_]: Concurrent] private (prefix: String, algebra: Fl
       } { id =>
         req
           .attemptAs[FleetRoute]
-          .foldF[ApiResult[FleetRoute]](
-            _ => EntryInvalidFormat.elevate[F, FleetRoute],
+          .foldF[ApiResult[Long]](
+            _ => EntryInvalidFormat.elevate[F, Long],
             fleetRoute =>
               if (id != fleetRoute.id) {
-                InconsistentIds(id, fleetRoute.id).elevate[F, FleetRoute]
+                InconsistentIds(id, fleetRoute.id).elevate[F, Long]
               } else {
                 algebra.updateFleetRoute(fleetRoute)
               }

--- a/src/main/scala/flightdatabase/api/endpoints/LanguageEndpoints.scala
+++ b/src/main/scala/flightdatabase/api/endpoints/LanguageEndpoints.scala
@@ -73,11 +73,11 @@ class LanguageEndpoints[F[_]: Concurrent] private (prefix: String, algebra: Lang
       } { id =>
         req
           .attemptAs[Language]
-          .foldF[ApiResult[Language]](
-            _ => EntryInvalidFormat.elevate[F, Language],
+          .foldF[ApiResult[Long]](
+            _ => EntryInvalidFormat.elevate[F, Long],
             lang =>
               if (id != lang.id) {
-                InconsistentIds(id, lang.id).elevate[F, Language]
+                InconsistentIds(id, lang.id).elevate[F, Long]
               } else {
                 algebra.updateLanguage(lang)
               }

--- a/src/main/scala/flightdatabase/api/endpoints/ManufacturerEndpoints.scala
+++ b/src/main/scala/flightdatabase/api/endpoints/ManufacturerEndpoints.scala
@@ -74,11 +74,11 @@ class ManufacturerEndpoints[F[_]: Concurrent] private (
       } { id =>
         req
           .attemptAs[Manufacturer]
-          .foldF[ApiResult[Manufacturer]](
-            _ => EntryInvalidFormat.elevate[F, Manufacturer],
+          .foldF[ApiResult[Long]](
+            _ => EntryInvalidFormat.elevate[F, Long],
             m =>
               if (id != m.id) {
-                InconsistentIds(id, m.id).elevate[F, Manufacturer]
+                InconsistentIds(id, m.id).elevate[F, Long]
               } else {
                 algebra.updateManufacturer(m)
               }

--- a/src/main/scala/flightdatabase/api/package.scala
+++ b/src/main/scala/flightdatabase/api/package.scala
@@ -28,7 +28,7 @@ package object api {
       case Left(value @ EntryAlreadyExists)        => Conflict(value.error)
       case Left(value @ FeatureNotImplemented)     => NotImplemented(value.error)
       case Left(value: EntryNotFound[_])           => NotFound(value.error)
-      case Left(value: UnknownError)               => UnprocessableEntity(value.error)
+      case Left(value: UnknownDbError)             => UnprocessableEntity(value.error)
     }
   }
 }

--- a/src/main/scala/flightdatabase/api/package.scala
+++ b/src/main/scala/flightdatabase/api/package.scala
@@ -23,6 +23,7 @@ package object api {
       case Left(value @ EntryInvalidFormat)        => BadRequest(value.error)
       case Left(value @ EntryHasInvalidForeignKey) => BadRequest(value.error)
       case Left(value: InconsistentIds)            => BadRequest(value.error)
+      case Left(value: InvalidTimezone)            => BadRequest(value.error)
       case Left(value @ EntryAlreadyExists)        => Conflict(value.error)
       case Left(value @ FeatureNotImplemented)     => NotImplemented(value.error)
       case Left(value: EntryNotFound[_])           => NotFound(value.error)

--- a/src/main/scala/flightdatabase/api/package.scala
+++ b/src/main/scala/flightdatabase/api/package.scala
@@ -24,6 +24,7 @@ package object api {
       case Left(value @ EntryHasInvalidForeignKey) => BadRequest(value.error)
       case Left(value: InconsistentIds)            => BadRequest(value.error)
       case Left(value: InvalidTimezone)            => BadRequest(value.error)
+      case Left(value: InvalidField)               => BadRequest(value.error)
       case Left(value @ EntryAlreadyExists)        => Conflict(value.error)
       case Left(value @ FeatureNotImplemented)     => NotImplemented(value.error)
       case Left(value: EntryNotFound[_])           => NotFound(value.error)

--- a/src/main/scala/flightdatabase/api/package.scala
+++ b/src/main/scala/flightdatabase/api/package.scala
@@ -25,7 +25,7 @@ package object api {
       case Left(value: InconsistentIds)            => BadRequest(value.error)
       case Left(value @ EntryAlreadyExists)        => Conflict(value.error)
       case Left(value @ FeatureNotImplemented)     => NotImplemented(value.error)
-      case Left(value: EntryNotFound)              => NotFound(value.error)
+      case Left(value: EntryNotFound[_])           => NotFound(value.error)
       case Left(value: UnknownError)               => UnprocessableEntity(value.error)
     }
   }

--- a/src/main/scala/flightdatabase/domain/ApiError.scala
+++ b/src/main/scala/flightdatabase/domain/ApiError.scala
@@ -56,4 +56,4 @@ case class InvalidField(field: String) extends ApiError {
   override val error: String = s"Error: Invalid field $field"
 }
 
-case class UnknownError(error: String) extends ApiError
+case class UnknownDbError(error: String) extends ApiError

--- a/src/main/scala/flightdatabase/domain/ApiError.scala
+++ b/src/main/scala/flightdatabase/domain/ApiError.scala
@@ -52,4 +52,8 @@ case class InvalidTimezone(timezone: String) extends ApiError {
   override val error: String = s"Error: Invalid timezone $timezone"
 }
 
+case class InvalidField(field: String) extends ApiError {
+  override val error: String = s"Error: Invalid field $field"
+}
+
 case class UnknownError(error: String) extends ApiError

--- a/src/main/scala/flightdatabase/domain/ApiError.scala
+++ b/src/main/scala/flightdatabase/domain/ApiError.scala
@@ -48,4 +48,8 @@ case object FeatureNotImplemented extends ApiError {
   override val error: String = "Error: Feature still under development..."
 }
 
+case class InvalidTimezone(timezone: String) extends ApiError {
+  override val error: String = s"Error: Invalid timezone $timezone"
+}
+
 case class UnknownError(error: String) extends ApiError

--- a/src/main/scala/flightdatabase/domain/ApiError.scala
+++ b/src/main/scala/flightdatabase/domain/ApiError.scala
@@ -40,7 +40,7 @@ case object EntryHasInvalidForeignKey extends ApiError {
   override val error: String = "Error: Entry has an invalid/non-existing foreign key"
 }
 
-case class EntryNotFound(entry: String) extends ApiError {
+case class EntryNotFound[A](entry: A) extends ApiError {
   override val error: String = s"Error: Entry $entry not found"
 }
 

--- a/src/main/scala/flightdatabase/domain/airplane/Airplane.scala
+++ b/src/main/scala/flightdatabase/domain/airplane/Airplane.scala
@@ -16,19 +16,14 @@ object Airplane {
 
   implicit val airplaneTableBase: TableBase[Airplane] = TableBase.instance(AIRPLANE)
 
-  def fromCreate(model: AirplaneCreate): Option[Airplane] =
-    model.id.map { id =>
-      Airplane(
-        id,
-        model.name,
-        model.manufacturerId,
-        model.capacity,
-        model.maxRangeInKm
-      )
-    }
-
-  def fromCreateUnsafe(model: AirplaneCreate): Airplane =
-    fromCreate(model).get
+  def fromCreate(id: Long, model: AirplaneCreate): Airplane =
+    Airplane(
+      id,
+      model.name,
+      model.manufacturerId,
+      model.capacity,
+      model.maxRangeInKm
+    )
 
   def fromPatch(id: Long, patch: AirplanePatch, original: Airplane): Airplane =
     Airplane(

--- a/src/main/scala/flightdatabase/domain/airplane/AirplaneAlgebra.scala
+++ b/src/main/scala/flightdatabase/domain/airplane/AirplaneAlgebra.scala
@@ -11,7 +11,7 @@ trait AirplaneAlgebra[F[_]] {
   def getAirplanes[V: Put](field: String, value: V): F[ApiResult[List[Airplane]]]
   def getAirplanesByManufacturer(manufacturer: String): F[ApiResult[List[Airplane]]]
   def createAirplane(airplane: AirplaneCreate): F[ApiResult[Long]]
-  def updateAirplane(airplane: Airplane): F[ApiResult[Airplane]]
+  def updateAirplane(airplane: Airplane): F[ApiResult[Long]]
   def partiallyUpdateAirplane(id: Long, patch: AirplanePatch): F[ApiResult[Airplane]]
   def removeAirplane(id: Long): F[ApiResult[Unit]]
 }

--- a/src/main/scala/flightdatabase/domain/airplane/AirplaneCreate.scala
+++ b/src/main/scala/flightdatabase/domain/airplane/AirplaneCreate.scala
@@ -10,3 +10,9 @@ import io.circe.generic.extras._
   capacity: Int,
   maxRangeInKm: Int
 )
+
+object AirplaneCreate {
+
+  def apply(name: String, manufacturerId: Long, capacity: Int, maxRangeInKm: Int): AirplaneCreate =
+    new AirplaneCreate(None, name, manufacturerId, capacity, maxRangeInKm)
+}

--- a/src/main/scala/flightdatabase/domain/airplane/AirplanePatch.scala
+++ b/src/main/scala/flightdatabase/domain/airplane/AirplanePatch.scala
@@ -4,8 +4,8 @@ import flightdatabase.domain._
 import io.circe.generic.extras._
 
 @ConfiguredJsonCodec final case class AirplanePatch(
-  name: Option[String],
-  manufacturerId: Option[Long],
-  capacity: Option[Int],
-  maxRangeInKm: Option[Int]
+  name: Option[String] = None,
+  manufacturerId: Option[Long] = None,
+  capacity: Option[Int] = None,
+  maxRangeInKm: Option[Int] = None
 )

--- a/src/main/scala/flightdatabase/domain/airport/Airport.scala
+++ b/src/main/scala/flightdatabase/domain/airport/Airport.scala
@@ -22,24 +22,19 @@ object Airport {
 
   implicit val airportTableBase: TableBase[Airport] = TableBase.instance(AIRPORT)
 
-  def fromCreate(model: AirportCreate): Option[Airport] =
-    model.id.map { id =>
-      Airport(
-        id,
-        model.name,
-        model.icao,
-        model.iata,
-        model.cityId,
-        model.numRunways,
-        model.numTerminals,
-        model.capacity,
-        model.international,
-        model.junction
-      )
-    }
-
-  def fromCreateUnsafe(model: AirportCreate): Airport =
-    fromCreate(model).get
+  def fromCreate(id: Long, model: AirportCreate): Airport =
+    Airport(
+      id,
+      model.name,
+      model.icao,
+      model.iata,
+      model.cityId,
+      model.numRunways,
+      model.numTerminals,
+      model.capacity,
+      model.international,
+      model.junction
+    )
 
   def fromPatch(id: Long, patch: AirportPatch, airport: Airport): Airport =
     Airport(

--- a/src/main/scala/flightdatabase/domain/airport/AirportAlgebra.scala
+++ b/src/main/scala/flightdatabase/domain/airport/AirportAlgebra.scala
@@ -8,11 +8,11 @@ trait AirportAlgebra[F[_]] {
   def getAirports: F[ApiResult[List[Airport]]]
   def getAirportsOnlyNames: F[ApiResult[List[String]]]
   def getAirport(id: Long): F[ApiResult[Airport]]
-  def getAirportsBy[V: Put](field: String, value: V): F[ApiResult[List[Airport]]]
+  def getAirports[V: Put](field: String, value: V): F[ApiResult[List[Airport]]]
   def getAirportsByCity(city: String): F[ApiResult[List[Airport]]]
   def getAirportsByCountry(country: String): F[ApiResult[List[Airport]]]
   def createAirport(airport: AirportCreate): F[ApiResult[Long]]
-  def updateAirport(airport: Airport): F[ApiResult[Airport]]
+  def updateAirport(airport: Airport): F[ApiResult[Long]]
   def partiallyUpdateAirport(id: Long, patch: AirportPatch): F[ApiResult[Airport]]
   def removeAirport(id: Long): F[ApiResult[Unit]]
 }

--- a/src/main/scala/flightdatabase/domain/airport/AirportCreate.scala
+++ b/src/main/scala/flightdatabase/domain/airport/AirportCreate.scala
@@ -15,3 +15,30 @@ import io.circe.generic.extras._
   international: Boolean,
   junction: Boolean
 )
+
+object AirportCreate {
+
+  def apply(
+    name: String,
+    icao: String,
+    iata: String,
+    cityId: Long,
+    numRunways: Int,
+    numTerminals: Int,
+    capacity: Long,
+    international: Boolean,
+    junction: Boolean
+  ): AirportCreate =
+    new AirportCreate(
+      None,
+      name,
+      icao,
+      iata,
+      cityId,
+      numRunways,
+      numTerminals,
+      capacity,
+      international,
+      junction
+    )
+}

--- a/src/main/scala/flightdatabase/domain/airport/AirportPatch.scala
+++ b/src/main/scala/flightdatabase/domain/airport/AirportPatch.scala
@@ -5,13 +5,13 @@ import io.circe.generic.extras.ConfiguredJsonCodec
 import io.circe.generic.extras.JsonKey
 
 @ConfiguredJsonCodec final case class AirportPatch(
-  name: Option[String],
-  icao: Option[String],
-  iata: Option[String],
-  cityId: Option[Long],
-  @JsonKey("number_of_runways") numRunways: Option[Int],
-  @JsonKey("number_of_terminals") numTerminals: Option[Int],
-  capacity: Option[Long],
-  international: Option[Boolean],
-  junction: Option[Boolean]
+  name: Option[String] = None,
+  icao: Option[String] = None,
+  iata: Option[String] = None,
+  cityId: Option[Long] = None,
+  @JsonKey("number_of_runways") numRunways: Option[Int] = None,
+  @JsonKey("number_of_terminals") numTerminals: Option[Int] = None,
+  capacity: Option[Long] = None,
+  international: Option[Boolean] = None,
+  junction: Option[Boolean] = None
 )

--- a/src/main/scala/flightdatabase/domain/city/City.scala
+++ b/src/main/scala/flightdatabase/domain/city/City.scala
@@ -18,22 +18,17 @@ import io.circe.generic.extras.ConfiguredJsonCodec
 object City {
   implicit val cityTableBase: TableBase[City] = TableBase.instance(CITY)
 
-  def fromCreate(model: CityCreate): Option[City] =
-    model.id.map { id =>
-      City(
-        id,
-        model.name,
-        model.countryId,
-        model.capital,
-        model.population,
-        model.latitude,
-        model.longitude,
-        model.timezone
-      )
-    }
-
-  def fromCreateUnsafe(model: CityCreate): City =
-    fromCreate(model).get
+  def fromCreate(id: Long, model: CityCreate): City =
+    City(
+      id,
+      model.name,
+      model.countryId,
+      model.capital,
+      model.population,
+      model.latitude,
+      model.longitude,
+      model.timezone
+    )
 
   def fromPatch(id: Long, patch: CityPatch, original: City): City =
     City(

--- a/src/main/scala/flightdatabase/domain/city/CityAlgebra.scala
+++ b/src/main/scala/flightdatabase/domain/city/CityAlgebra.scala
@@ -15,4 +15,6 @@ trait CityAlgebra[F[_]] {
   def updateCity(city: City): F[ApiResult[Long]]
   def partiallyUpdateCity(id: Long, patch: CityPatch): F[ApiResult[City]]
   def removeCity(id: Long): F[ApiResult[Unit]]
+
+  protected def validateTimezone(timezone: String, countryId: Long): F[ApiResult[Unit]]
 }

--- a/src/main/scala/flightdatabase/domain/city/CityAlgebra.scala
+++ b/src/main/scala/flightdatabase/domain/city/CityAlgebra.scala
@@ -12,7 +12,7 @@ trait CityAlgebra[F[_]] {
   def getCities[V: Put](field: String, value: V): F[ApiResult[List[City]]]
   def getCitiesByCountry(country: String): F[ApiResult[List[City]]]
   def createCity(city: CityCreate): F[ApiResult[Long]]
-  def updateCity(city: City): F[ApiResult[City]]
+  def updateCity(city: City): F[ApiResult[Long]]
   def partiallyUpdateCity(id: Long, patch: CityPatch): F[ApiResult[City]]
   def removeCity(id: Long): F[ApiResult[Unit]]
 }

--- a/src/main/scala/flightdatabase/domain/city/CityCreate.scala
+++ b/src/main/scala/flightdatabase/domain/city/CityCreate.scala
@@ -13,3 +13,26 @@ import io.circe.generic.extras.ConfiguredJsonCodec
   longitude: BigDecimal,
   timezone: String
 )
+
+object CityCreate {
+
+  def apply(
+    name: String,
+    countryId: Long,
+    capital: Boolean,
+    population: Long,
+    latitude: BigDecimal,
+    longitude: BigDecimal,
+    timezone: String
+  ): CityCreate =
+    new CityCreate(
+      None,
+      name,
+      countryId,
+      capital,
+      population,
+      latitude,
+      longitude,
+      timezone
+    )
+}

--- a/src/main/scala/flightdatabase/domain/city/CityPatch.scala
+++ b/src/main/scala/flightdatabase/domain/city/CityPatch.scala
@@ -4,11 +4,11 @@ import flightdatabase.domain._
 import io.circe.generic.extras.ConfiguredJsonCodec
 
 @ConfiguredJsonCodec final case class CityPatch(
-  name: Option[String],
-  countryId: Option[Long],
-  capital: Option[Boolean],
-  population: Option[Long],
-  latitude: Option[BigDecimal],
-  longitude: Option[BigDecimal],
-  timezone: Option[String]
+  name: Option[String] = None,
+  countryId: Option[Long] = None,
+  capital: Option[Boolean] = None,
+  population: Option[Long] = None,
+  latitude: Option[BigDecimal] = None,
+  longitude: Option[BigDecimal] = None,
+  timezone: Option[String] = None
 )

--- a/src/main/scala/flightdatabase/domain/country/Country.scala
+++ b/src/main/scala/flightdatabase/domain/country/Country.scala
@@ -21,25 +21,20 @@ import io.circe.generic.extras.ConfiguredJsonCodec
 object Country {
   implicit val countryTableBase: TableBase[Country] = TableBase.instance(COUNTRY)
 
-  def fromCreate(model: CountryCreate): Option[Country] =
-    model.id.map { id =>
-      Country(
-        id = id,
-        name = model.name,
-        iso2 = model.iso2,
-        iso3 = model.iso3,
-        countryCode = model.countryCode,
-        domainName = model.domainName,
-        mainLanguageId = model.mainLanguageId,
-        secondaryLanguageId = model.secondaryLanguageId,
-        tertiaryLanguageId = model.tertiaryLanguageId,
-        currencyId = model.currencyId,
-        nationality = model.nationality
-      )
-    }
-
-  def fromCreateUnsafe(model: CountryCreate): Country =
-    fromCreate(model).get
+  def fromCreate(id: Long, model: CountryCreate): Country =
+    Country(
+      id = id,
+      name = model.name,
+      iso2 = model.iso2,
+      iso3 = model.iso3,
+      countryCode = model.countryCode,
+      domainName = model.domainName,
+      mainLanguageId = model.mainLanguageId,
+      secondaryLanguageId = model.secondaryLanguageId,
+      tertiaryLanguageId = model.tertiaryLanguageId,
+      currencyId = model.currencyId,
+      nationality = model.nationality
+    )
 
   def fromPatch(id: Long, patch: CountryPatch, original: Country): Country =
     Country(

--- a/src/main/scala/flightdatabase/domain/country/CountryAlgebra.scala
+++ b/src/main/scala/flightdatabase/domain/country/CountryAlgebra.scala
@@ -11,7 +11,7 @@ trait CountryAlgebra[F[_]] {
   def getCountry(id: Long): F[ApiResult[Country]]
   def getCountries[V: Put](field: String, value: V): F[ApiResult[List[Country]]]
   def createCountry(country: CountryCreate): F[ApiResult[Long]]
-  def updateCountry(country: Country): F[ApiResult[Country]]
+  def updateCountry(country: Country): F[ApiResult[Long]]
   def partiallyUpdateCountry(id: Long, patch: CountryPatch): F[ApiResult[Country]]
   def removeCountry(id: Long): F[ApiResult[Unit]]
 }

--- a/src/main/scala/flightdatabase/domain/country/CountryAlgebra.scala
+++ b/src/main/scala/flightdatabase/domain/country/CountryAlgebra.scala
@@ -10,6 +10,8 @@ trait CountryAlgebra[F[_]] {
   def getCountriesOnlyNames: F[ApiResult[List[String]]]
   def getCountry(id: Long): F[ApiResult[Country]]
   def getCountries[V: Put](field: String, value: V): F[ApiResult[List[Country]]]
+  def getCountriesByLanguage[V: Put](field: String, value: V): F[ApiResult[List[Country]]]
+  def getCountriesByCurrency[V: Put](field: String, value: V): F[ApiResult[List[Country]]]
   def createCountry(country: CountryCreate): F[ApiResult[Long]]
   def updateCountry(country: Country): F[ApiResult[Long]]
   def partiallyUpdateCountry(id: Long, patch: CountryPatch): F[ApiResult[Country]]

--- a/src/main/scala/flightdatabase/domain/country/CountryCreate.scala
+++ b/src/main/scala/flightdatabase/domain/country/CountryCreate.scala
@@ -16,3 +16,32 @@ import io.circe.generic.extras.ConfiguredJsonCodec
   currencyId: Long,
   nationality: String
 )
+
+object CountryCreate {
+
+  def apply(
+    name: String,
+    iso2: String,
+    iso3: String,
+    countryCode: Int,
+    domainName: Option[String],
+    mainLanguageId: Long,
+    secondaryLanguageId: Option[Long],
+    tertiaryLanguageId: Option[Long],
+    currencyId: Long,
+    nationality: String
+  ): CountryCreate =
+    new CountryCreate(
+      None,
+      name,
+      iso2,
+      iso3,
+      countryCode,
+      domainName,
+      mainLanguageId,
+      secondaryLanguageId,
+      tertiaryLanguageId,
+      currencyId,
+      nationality
+    )
+}

--- a/src/main/scala/flightdatabase/domain/country/CountryPatch.scala
+++ b/src/main/scala/flightdatabase/domain/country/CountryPatch.scala
@@ -4,14 +4,14 @@ import flightdatabase.domain._
 import io.circe.generic.extras.ConfiguredJsonCodec
 
 @ConfiguredJsonCodec final case class CountryPatch(
-  name: Option[String],
-  iso2: Option[String],
-  iso3: Option[String],
-  countryCode: Option[Int],
-  domainName: Option[String],
-  mainLanguageId: Option[Long],
-  secondaryLanguageId: Option[Long],
-  tertiaryLanguageId: Option[Long],
-  currencyId: Option[Long],
-  nationality: Option[String]
+  name: Option[String] = None,
+  iso2: Option[String] = None,
+  iso3: Option[String] = None,
+  countryCode: Option[Int] = None,
+  domainName: Option[String] = None,
+  mainLanguageId: Option[Long] = None,
+  secondaryLanguageId: Option[Long] = None,
+  tertiaryLanguageId: Option[Long] = None,
+  currencyId: Option[Long] = None,
+  nationality: Option[String] = None
 )

--- a/src/main/scala/flightdatabase/domain/currency/Currency.scala
+++ b/src/main/scala/flightdatabase/domain/currency/Currency.scala
@@ -14,18 +14,13 @@ import io.circe.generic.extras.ConfiguredJsonCodec
 object Currency {
   implicit val currencyTableBase: TableBase[Currency] = TableBase.instance(CURRENCY)
 
-  def fromCreate(model: CurrencyCreate): Option[Currency] =
-    model.id.map { id =>
-      Currency(
-        id,
-        model.name,
-        model.iso,
-        model.symbol
-      )
-    }
-
-  def fromCreateUnsafe(model: CurrencyCreate): Currency =
-    fromCreate(model).get
+  def fromCreate(id: Long, model: CurrencyCreate): Currency =
+    Currency(
+      id,
+      model.name,
+      model.iso,
+      model.symbol
+    )
 
   def fromPatch(id: Long, patch: CurrencyPatch, currency: Currency): Currency =
     Currency(

--- a/src/main/scala/flightdatabase/domain/currency/CurrencyAlgebra.scala
+++ b/src/main/scala/flightdatabase/domain/currency/CurrencyAlgebra.scala
@@ -10,7 +10,7 @@ trait CurrencyAlgebra[F[_]] {
   def getCurrency(id: Long): F[ApiResult[Currency]]
   def getCurrencies[V: Put](field: String, value: V): F[ApiResult[List[Currency]]]
   def createCurrency(currency: CurrencyCreate): F[ApiResult[Long]]
-  def updateCurrency(currency: Currency): F[ApiResult[Currency]]
+  def updateCurrency(currency: Currency): F[ApiResult[Long]]
   def partiallyUpdateCurrency(id: Long, patch: CurrencyPatch): F[ApiResult[Currency]]
   def removeCurrency(id: Long): F[ApiResult[Unit]]
 }

--- a/src/main/scala/flightdatabase/domain/currency/CurrencyCreate.scala
+++ b/src/main/scala/flightdatabase/domain/currency/CurrencyCreate.scala
@@ -9,3 +9,18 @@ import io.circe.generic.extras.ConfiguredJsonCodec
   iso: String,
   symbol: Option[String]
 )
+
+object CurrencyCreate {
+
+  def apply(
+    name: String,
+    iso: String,
+    symbol: Option[String]
+  ): CurrencyCreate =
+    new CurrencyCreate(
+      None,
+      name,
+      iso,
+      symbol
+    )
+}

--- a/src/main/scala/flightdatabase/domain/currency/CurrencyPatch.scala
+++ b/src/main/scala/flightdatabase/domain/currency/CurrencyPatch.scala
@@ -4,7 +4,7 @@ import flightdatabase.domain._
 import io.circe.generic.extras.ConfiguredJsonCodec
 
 @ConfiguredJsonCodec final case class CurrencyPatch(
-  name: Option[String],
-  iso: Option[String],
-  symbol: Option[String]
+  name: Option[String] = None,
+  iso: Option[String] = None,
+  symbol: Option[String] = None
 )

--- a/src/main/scala/flightdatabase/domain/fleet/Fleet.scala
+++ b/src/main/scala/flightdatabase/domain/fleet/Fleet.scala
@@ -16,20 +16,15 @@ import io.circe.generic.extras._
 object Fleet {
   implicit val fleetTableBase: TableBase[Fleet] = TableBase.instance(FLEET)
 
-  def fromCreate(model: FleetCreate): Option[Fleet] =
-    model.id.map { id =>
-      Fleet(
-        id,
-        model.name,
-        model.iso2,
-        model.iso3,
-        model.callSign,
-        model.hubAt
-      )
-    }
-
-  def fromCreateUnsafe(model: FleetCreate): Fleet =
-    fromCreate(model).get
+  def fromCreate(id: Long, model: FleetCreate): Fleet =
+    Fleet(
+      id,
+      model.name,
+      model.iso2,
+      model.iso3,
+      model.callSign,
+      model.hubAt
+    )
 
   def fromPatch(id: Long, patch: FleetPatch, original: Fleet): Fleet =
     Fleet(

--- a/src/main/scala/flightdatabase/domain/fleet/FleetAlgebra.scala
+++ b/src/main/scala/flightdatabase/domain/fleet/FleetAlgebra.scala
@@ -12,7 +12,7 @@ trait FleetAlgebra[F[_]] {
   def getFleetByHubAirportIata(hubAirportIata: String): F[ApiResult[List[Fleet]]]
   def getFleetByHubAirportIcao(hubAirportIcao: String): F[ApiResult[List[Fleet]]]
   def createFleet(fleet: FleetCreate): F[ApiResult[Long]]
-  def updateFleet(fleet: Fleet): F[ApiResult[Fleet]]
+  def updateFleet(fleet: Fleet): F[ApiResult[Long]]
   def partiallyUpdateFleet(id: Long, patch: FleetPatch): F[ApiResult[Fleet]]
   def removeFleet(id: Long): F[ApiResult[Unit]]
 }

--- a/src/main/scala/flightdatabase/domain/fleet/FleetCreate.scala
+++ b/src/main/scala/flightdatabase/domain/fleet/FleetCreate.scala
@@ -11,3 +11,22 @@ import io.circe.generic.extras._
   callSign: String,
   @JsonKey("hub_airport_id") hubAt: Long
 )
+
+object FleetCreate {
+
+  def apply(
+    name: String,
+    iso2: String,
+    iso3: String,
+    callSign: String,
+    hubAt: Long
+  ): FleetCreate =
+    new FleetCreate(
+      None,
+      name,
+      iso2,
+      iso3,
+      callSign,
+      hubAt
+    )
+}

--- a/src/main/scala/flightdatabase/domain/fleet/FleetPatch.scala
+++ b/src/main/scala/flightdatabase/domain/fleet/FleetPatch.scala
@@ -4,9 +4,9 @@ import flightdatabase.domain._
 import io.circe.generic.extras._
 
 @ConfiguredJsonCodec final case class FleetPatch(
-  name: Option[String],
-  iso2: Option[String],
-  iso3: Option[String],
-  callSign: Option[String],
-  @JsonKey("hub_airport_id") hubAt: Option[Long]
+  name: Option[String] = None,
+  iso2: Option[String] = None,
+  iso3: Option[String] = None,
+  callSign: Option[String] = None,
+  @JsonKey("hub_airport_id") hubAt: Option[Long] = None
 )

--- a/src/main/scala/flightdatabase/domain/fleet_airplane/FleetAirplane.scala
+++ b/src/main/scala/flightdatabase/domain/fleet_airplane/FleetAirplane.scala
@@ -13,17 +13,12 @@ import io.circe.generic.extras.ConfiguredJsonCodec
 object FleetAirplane {
   implicit val fleetAirplaneTableBase: TableBase[FleetAirplane] = TableBase.instance(FLEET_AIRPLANE)
 
-  def fromCreate(model: FleetAirplaneCreate): Option[FleetAirplane] =
-    model.id.map { id =>
-      FleetAirplane(
-        id,
-        model.fleetId,
-        model.airplaneId
-      )
-    }
-
-  def fromCreateUnsafe(model: FleetAirplaneCreate): FleetAirplane =
-    fromCreate(model).get
+  def fromCreate(id: Long, model: FleetAirplaneCreate): FleetAirplane =
+    FleetAirplane(
+      id,
+      model.fleetId,
+      model.airplaneId
+    )
 
   def fromPatch(id: Long, patch: FleetAirplanePatch, original: FleetAirplane): FleetAirplane =
     FleetAirplane(

--- a/src/main/scala/flightdatabase/domain/fleet_airplane/FleetAirplaneAlgebra.scala
+++ b/src/main/scala/flightdatabase/domain/fleet_airplane/FleetAirplaneAlgebra.scala
@@ -17,7 +17,7 @@ trait FleetAirplaneAlgebra[F[_]] {
   def getFleetAirplanesByAirplaneName(airplaneName: String): F[ApiResult[List[FleetAirplane]]]
   def getFleetAirplanesByFleetName(fleetName: String): F[ApiResult[List[FleetAirplane]]]
   def createFleetAirplane(fleetAirplane: FleetAirplaneCreate): F[ApiResult[Long]]
-  def updateFleetAirplane(fleetAirplane: FleetAirplane): F[ApiResult[FleetAirplane]]
+  def updateFleetAirplane(fleetAirplane: FleetAirplane): F[ApiResult[Long]]
   def partiallyUpdateFleetAirplane(id: Long, patch: FleetAirplanePatch): F[ApiResult[FleetAirplane]]
   def removeFleetAirplane(id: Long): F[ApiResult[Unit]]
 }

--- a/src/main/scala/flightdatabase/domain/fleet_airplane/FleetAirplaneAlgebra.scala
+++ b/src/main/scala/flightdatabase/domain/fleet_airplane/FleetAirplaneAlgebra.scala
@@ -8,6 +8,7 @@ trait FleetAirplaneAlgebra[F[_]] {
   def doesFleetAirplaneExist(id: Long): F[Boolean]
   def getFleetAirplanes: F[ApiResult[List[FleetAirplane]]]
   def getFleetAirplane(id: Long): F[ApiResult[FleetAirplane]]
+  def getFleetAirplane(fleetId: Long, airplaneId: Long): F[ApiResult[FleetAirplane]]
   def getFleetAirplanes[V: Put](field: String, value: V): F[ApiResult[List[FleetAirplane]]]
 
   def getFleetAirplanesByExternal[ET: TableBase, EV: Put](

--- a/src/main/scala/flightdatabase/domain/fleet_airplane/FleetAirplaneCreate.scala
+++ b/src/main/scala/flightdatabase/domain/fleet_airplane/FleetAirplaneCreate.scala
@@ -8,3 +8,16 @@ import io.circe.generic.extras.ConfiguredJsonCodec
   fleetId: Long,
   airplaneId: Long
 )
+
+object FleetAirplaneCreate {
+
+  def apply(
+    fleetId: Long,
+    airplaneId: Long
+  ): FleetAirplaneCreate =
+    new FleetAirplaneCreate(
+      None,
+      fleetId,
+      airplaneId
+    )
+}

--- a/src/main/scala/flightdatabase/domain/fleet_airplane/FleetAirplanePatch.scala
+++ b/src/main/scala/flightdatabase/domain/fleet_airplane/FleetAirplanePatch.scala
@@ -4,6 +4,6 @@ import flightdatabase.domain._
 import io.circe.generic.extras.ConfiguredJsonCodec
 
 @ConfiguredJsonCodec final case class FleetAirplanePatch(
-  fleetId: Option[Long],
-  airplaneId: Option[Long]
+  fleetId: Option[Long] = None,
+  airplaneId: Option[Long] = None
 )

--- a/src/main/scala/flightdatabase/domain/fleet_route/FleetRoute.scala
+++ b/src/main/scala/flightdatabase/domain/fleet_route/FleetRoute.scala
@@ -15,19 +15,14 @@ import io.circe.generic.extras._
 object FleetRoute {
   implicit val fleetRouteTableBase: TableBase[FleetRoute] = TableBase.instance(FLEET_ROUTE)
 
-  def fromCreate(model: FleetRouteCreate): Option[FleetRoute] =
-    model.id.map { id =>
-      FleetRoute(
-        id,
-        model.fleetAirplaneId,
-        model.route,
-        model.start,
-        model.destination
-      )
-    }
-
-  def fromCreateUnsafe(model: FleetRouteCreate): FleetRoute =
-    fromCreate(model).get
+  def fromCreate(id: Long, model: FleetRouteCreate): FleetRoute =
+    FleetRoute(
+      id,
+      model.fleetAirplaneId,
+      model.route,
+      model.start,
+      model.destination
+    )
 
   def fromPatch(id: Long, patch: FleetRoutePatch, original: FleetRoute): FleetRoute =
     FleetRoute(

--- a/src/main/scala/flightdatabase/domain/fleet_route/FleetRouteAlgebra.scala
+++ b/src/main/scala/flightdatabase/domain/fleet_route/FleetRouteAlgebra.scala
@@ -18,7 +18,7 @@ trait FleetRouteAlgebra[F[_]] {
     inbound: Option[Boolean]
   ): F[ApiResult[List[FleetRoute]]]
   def createFleetRoute(fleetRoute: FleetRouteCreate): F[ApiResult[Long]]
-  def updateFleetRoute(fleetRoute: FleetRoute): F[ApiResult[FleetRoute]]
+  def updateFleetRoute(fleetRoute: FleetRoute): F[ApiResult[Long]]
   def partiallyUpdateFleetRoute(id: Long, patch: FleetRoutePatch): F[ApiResult[FleetRoute]]
   def removeFleetRoute(id: Long): F[ApiResult[Unit]]
 }

--- a/src/main/scala/flightdatabase/domain/fleet_route/FleetRouteCreate.scala
+++ b/src/main/scala/flightdatabase/domain/fleet_route/FleetRouteCreate.scala
@@ -10,3 +10,20 @@ import io.circe.generic.extras._
   @JsonKey("start_airport_id") start: Long,
   @JsonKey("destination_airport_id") destination: Long
 )
+
+object FleetRouteCreate {
+
+  def apply(
+    fleetAirplaneId: Long,
+    route: String,
+    start: Long,
+    destination: Long
+  ): FleetRouteCreate =
+    new FleetRouteCreate(
+      None,
+      fleetAirplaneId,
+      route,
+      start,
+      destination
+    )
+}

--- a/src/main/scala/flightdatabase/domain/fleet_route/FleetRoutePatch.scala
+++ b/src/main/scala/flightdatabase/domain/fleet_route/FleetRoutePatch.scala
@@ -4,8 +4,8 @@ import flightdatabase.domain._
 import io.circe.generic.extras._
 
 @ConfiguredJsonCodec final case class FleetRoutePatch(
-  fleetAirplaneId: Option[Long],
-  @JsonKey("route_number") route: Option[String],
-  @JsonKey("start_airport_id") start: Option[Long],
-  @JsonKey("destination_airport_id") destination: Option[Long]
+  fleetAirplaneId: Option[Long] = None,
+  @JsonKey("route_number") route: Option[String] = None,
+  @JsonKey("start_airport_id") start: Option[Long] = None,
+  @JsonKey("destination_airport_id") destination: Option[Long] = None
 )

--- a/src/main/scala/flightdatabase/domain/language/Language.scala
+++ b/src/main/scala/flightdatabase/domain/language/Language.scala
@@ -15,19 +15,14 @@ import io.circe.generic.extras.ConfiguredJsonCodec
 object Language {
   implicit val languageTableBase: TableBase[Language] = TableBase.instance(LANGUAGE)
 
-  def fromCreate(model: LanguageCreate): Option[Language] =
-    model.id.map { id =>
-      Language(
-        id,
-        model.name,
-        model.iso2,
-        model.iso3,
-        model.originalName
-      )
-    }
-
-  def fromCreateUnsafe(model: LanguageCreate): Language =
-    fromCreate(model).get
+  def fromCreate(id: Long, model: LanguageCreate): Language =
+    Language(
+      id,
+      model.name,
+      model.iso2,
+      model.iso3,
+      model.originalName
+    )
 
   def fromPatch(id: Long, patch: LanguagePatch, original: Language): Language =
     Language(

--- a/src/main/scala/flightdatabase/domain/language/LanguageAlgebra.scala
+++ b/src/main/scala/flightdatabase/domain/language/LanguageAlgebra.scala
@@ -10,7 +10,7 @@ trait LanguageAlgebra[F[_]] {
   def getLanguage(id: Long): F[ApiResult[Language]]
   def getLanguages[V: Put](field: String, value: V): F[ApiResult[List[Language]]]
   def createLanguage(language: LanguageCreate): F[ApiResult[Long]]
-  def updateLanguage(language: Language): F[ApiResult[Language]]
+  def updateLanguage(language: Language): F[ApiResult[Long]]
   def partiallyUpdateLanguage(id: Long, patch: LanguagePatch): F[ApiResult[Language]]
   def removeLanguage(id: Long): F[ApiResult[Unit]]
 }

--- a/src/main/scala/flightdatabase/domain/language/LanguageCreate.scala
+++ b/src/main/scala/flightdatabase/domain/language/LanguageCreate.scala
@@ -10,3 +10,20 @@ import io.circe.generic.extras.ConfiguredJsonCodec
   iso3: Option[String],
   originalName: String
 )
+
+object LanguageCreate {
+
+  def apply(
+    name: String,
+    iso2: String,
+    iso3: Option[String],
+    originalName: String
+  ): LanguageCreate =
+    new LanguageCreate(
+      None,
+      name,
+      iso2,
+      iso3,
+      originalName
+    )
+}

--- a/src/main/scala/flightdatabase/domain/language/LanguagePatch.scala
+++ b/src/main/scala/flightdatabase/domain/language/LanguagePatch.scala
@@ -4,8 +4,8 @@ import flightdatabase.domain._
 import io.circe.generic.extras.ConfiguredJsonCodec
 
 @ConfiguredJsonCodec final case class LanguagePatch(
-  name: Option[String],
-  iso2: Option[String],
-  iso3: Option[String],
-  originalName: Option[String]
+  name: Option[String] = None,
+  iso2: Option[String] = None,
+  iso3: Option[String] = None,
+  originalName: Option[String] = None
 )

--- a/src/main/scala/flightdatabase/domain/manufacturer/Manufacturer.scala
+++ b/src/main/scala/flightdatabase/domain/manufacturer/Manufacturer.scala
@@ -3,12 +3,11 @@ package flightdatabase.domain.manufacturer
 import flightdatabase.domain.FlightDbTable.MANUFACTURER
 import flightdatabase.domain._
 import io.circe.generic.extras.ConfiguredJsonCodec
-import io.circe.generic.extras.JsonKey
 
 @ConfiguredJsonCodec final case class Manufacturer(
   id: Long,
   name: String,
-  @JsonKey("city_based_in") basedIn: Long
+  cityBasedIn: Long
 )
 
 object Manufacturer {
@@ -18,13 +17,13 @@ object Manufacturer {
     Manufacturer(
       id,
       model.name,
-      model.basedIn
+      model.cityBasedIn
     )
 
   def fromPatch(id: Long, patch: ManufacturerPatch, original: Manufacturer): Manufacturer =
     Manufacturer(
       id,
       patch.name.getOrElse(original.name),
-      patch.basedIn.getOrElse(original.basedIn)
+      patch.cityBasedIn.getOrElse(original.cityBasedIn)
     )
 }

--- a/src/main/scala/flightdatabase/domain/manufacturer/Manufacturer.scala
+++ b/src/main/scala/flightdatabase/domain/manufacturer/Manufacturer.scala
@@ -14,17 +14,12 @@ import io.circe.generic.extras.JsonKey
 object Manufacturer {
   implicit val manufacturerTableBase: TableBase[Manufacturer] = TableBase.instance(MANUFACTURER)
 
-  def fromCreate(model: ManufacturerCreate): Option[Manufacturer] =
-    model.id.map { id =>
-      Manufacturer(
-        id,
-        model.name,
-        model.basedIn
-      )
-    }
-
-  def fromCreateUnsafe(model: ManufacturerCreate): Manufacturer =
-    fromCreate(model).get
+  def fromCreate(id: Long, model: ManufacturerCreate): Manufacturer =
+    Manufacturer(
+      id,
+      model.name,
+      model.basedIn
+    )
 
   def fromPatch(id: Long, patch: ManufacturerPatch, original: Manufacturer): Manufacturer =
     Manufacturer(

--- a/src/main/scala/flightdatabase/domain/manufacturer/ManufacturerAlgebra.scala
+++ b/src/main/scala/flightdatabase/domain/manufacturer/ManufacturerAlgebra.scala
@@ -12,7 +12,7 @@ trait ManufacturerAlgebra[F[_]] {
   def getManufacturersByCity(city: String): F[ApiResult[List[Manufacturer]]]
   def getManufacturersByCountry(country: String): F[ApiResult[List[Manufacturer]]]
   def createManufacturer(manufacturer: ManufacturerCreate): F[ApiResult[Long]]
-  def updateManufacturer(manufacturer: Manufacturer): F[ApiResult[Manufacturer]]
+  def updateManufacturer(manufacturer: Manufacturer): F[ApiResult[Long]]
   def partiallyUpdateManufacturer(id: Long, patch: ManufacturerPatch): F[ApiResult[Manufacturer]]
   def removeManufacturer(id: Long): F[ApiResult[Unit]]
 }

--- a/src/main/scala/flightdatabase/domain/manufacturer/ManufacturerCreate.scala
+++ b/src/main/scala/flightdatabase/domain/manufacturer/ManufacturerCreate.scala
@@ -8,3 +8,16 @@ import io.circe.generic.extras._
   name: String,
   @JsonKey("city_based_in") basedIn: Long
 )
+
+object ManufacturerCreate {
+
+  def apply(
+    name: String,
+    basedIn: Long
+  ): ManufacturerCreate =
+    new ManufacturerCreate(
+      None,
+      name,
+      basedIn
+    )
+}

--- a/src/main/scala/flightdatabase/domain/manufacturer/ManufacturerCreate.scala
+++ b/src/main/scala/flightdatabase/domain/manufacturer/ManufacturerCreate.scala
@@ -1,23 +1,23 @@
 package flightdatabase.domain.manufacturer
 
 import flightdatabase.domain._
-import io.circe.generic.extras._
+import io.circe.generic.extras.ConfiguredJsonCodec
 
 @ConfiguredJsonCodec final case class ManufacturerCreate(
   id: Option[Long],
   name: String,
-  @JsonKey("city_based_in") basedIn: Long
+  cityBasedIn: Long
 )
 
 object ManufacturerCreate {
 
   def apply(
     name: String,
-    basedIn: Long
+    cityBasedIn: Long
   ): ManufacturerCreate =
     new ManufacturerCreate(
       None,
       name,
-      basedIn
+      cityBasedIn
     )
 }

--- a/src/main/scala/flightdatabase/domain/manufacturer/ManufacturerPatch.scala
+++ b/src/main/scala/flightdatabase/domain/manufacturer/ManufacturerPatch.scala
@@ -5,6 +5,6 @@ import io.circe.generic.extras.ConfiguredJsonCodec
 import io.circe.generic.extras.JsonKey
 
 @ConfiguredJsonCodec final case class ManufacturerPatch(
-  name: Option[String],
-  @JsonKey("city_based_in") basedIn: Option[Long]
+  name: Option[String] = None,
+  @JsonKey("city_based_in") basedIn: Option[Long] = None
 )

--- a/src/main/scala/flightdatabase/domain/manufacturer/ManufacturerPatch.scala
+++ b/src/main/scala/flightdatabase/domain/manufacturer/ManufacturerPatch.scala
@@ -2,9 +2,8 @@ package flightdatabase.domain.manufacturer
 
 import flightdatabase.domain._
 import io.circe.generic.extras.ConfiguredJsonCodec
-import io.circe.generic.extras.JsonKey
 
 @ConfiguredJsonCodec final case class ManufacturerPatch(
   name: Option[String] = None,
-  @JsonKey("city_based_in") basedIn: Option[Long] = None
+  cityBasedIn: Option[Long] = None
 )

--- a/src/main/scala/flightdatabase/repository/AirplaneRepository.scala
+++ b/src/main/scala/flightdatabase/repository/AirplaneRepository.scala
@@ -39,8 +39,8 @@ class AirplaneRepository[F[_]: Concurrent] private (
   override def createAirplane(airplane: AirplaneCreate): F[ApiResult[Long]] =
     insertAirplane(airplane).attemptInsert.execute
 
-  override def updateAirplane(airplane: Airplane): F[ApiResult[Airplane]] =
-    modifyAirplane(airplane).attemptUpdate(airplane).execute
+  override def updateAirplane(airplane: Airplane): F[ApiResult[Long]] =
+    modifyAirplane(airplane).attemptUpdate(airplane.id).execute
 
   override def partiallyUpdateAirplane(
     id: Long,
@@ -48,7 +48,8 @@ class AirplaneRepository[F[_]: Concurrent] private (
   ): F[ApiResult[Airplane]] =
     EitherT(getAirplane(id)).flatMapF { airplaneOutput =>
       val airplane = airplaneOutput.value
-      updateAirplane(Airplane.fromPatch(id, patch, airplane))
+      val patched = Airplane.fromPatch(id, patch, airplane)
+      modifyAirplane(patched).attemptUpdate(patched).execute
     }.value
 
   override def removeAirplane(id: Long): F[ApiResult[Unit]] =

--- a/src/main/scala/flightdatabase/repository/CityRepository.scala
+++ b/src/main/scala/flightdatabase/repository/CityRepository.scala
@@ -37,13 +37,14 @@ class CityRepository[F[_]: Concurrent] private (
   override def createCity(city: CityCreate): F[ApiResult[Long]] =
     insertCity(city).attemptInsert.execute
 
-  override def updateCity(city: City): F[ApiResult[City]] =
-    modifyCity(city).attemptUpdate(city).execute
+  override def updateCity(city: City): F[ApiResult[Long]] =
+    modifyCity(city).attemptUpdate(city.id).execute
 
   override def partiallyUpdateCity(id: Long, patch: CityPatch): F[ApiResult[City]] =
     EitherT(getCity(id)).flatMapF { cityOutput =>
       val city = cityOutput.value
-      updateCity(City.fromPatch(id, patch, city))
+      val patched = City.fromPatch(id, patch, city)
+      modifyCity(patched).attemptUpdate(patched).execute
     }.value
 
   override def removeCity(id: Long): F[ApiResult[Unit]] =

--- a/src/main/scala/flightdatabase/repository/CityRepository.scala
+++ b/src/main/scala/flightdatabase/repository/CityRepository.scala
@@ -34,6 +34,9 @@ class CityRepository[F[_]: Concurrent] private (
   override def getCitiesByCountry(country: String): F[ApiResult[List[City]]] =
     selectCitiesByExternal[Country, String]("name", country).asList.execute
 
+  // TODO: Add checks for latitude/longitude <-> country matching
+  //  and for timezone validity
+  //  and for timezone <-> country matching
   override def createCity(city: CityCreate): F[ApiResult[Long]] =
     insertCity(city).attemptInsert.execute
 

--- a/src/main/scala/flightdatabase/repository/CityRepository.scala
+++ b/src/main/scala/flightdatabase/repository/CityRepository.scala
@@ -4,15 +4,17 @@ import cats.data.EitherT
 import cats.effect.Concurrent
 import cats.effect.Resource
 import cats.implicits._
+import com.ibm.icu.util.TimeZone
 import doobie.Put
 import doobie.Transactor
-import flightdatabase.domain.ApiResult
+import flightdatabase.domain._
 import flightdatabase.domain.city.City
 import flightdatabase.domain.city.CityAlgebra
 import flightdatabase.domain.city.CityCreate
 import flightdatabase.domain.city.CityPatch
 import flightdatabase.domain.country.Country
 import flightdatabase.repository.queries.CityQueries._
+import flightdatabase.repository.queries.CountryQueries
 import flightdatabase.utils.implicits._
 
 class CityRepository[F[_]: Concurrent] private (
@@ -34,24 +36,53 @@ class CityRepository[F[_]: Concurrent] private (
   override def getCitiesByCountry(country: String): F[ApiResult[List[City]]] =
     selectCitiesByExternal[Country, String]("name", country).asList.execute
 
-  // TODO: Add checks for latitude/longitude <-> country matching
-  //  and for timezone validity
-  //  and for timezone <-> country matching
+  // Do we need checks for latitude/longitude <-> country matching?
   override def createCity(city: CityCreate): F[ApiResult[Long]] =
-    insertCity(city).attemptInsert.execute
+    validateTimezone(city.timezone, city.countryId).flatMap {
+      case Left(error) => error.elevate[F, Long]
+      case Right(_)    => insertCity(city).attemptInsert.execute
+    }
 
   override def updateCity(city: City): F[ApiResult[Long]] =
-    modifyCity(city).attemptUpdate(city.id).execute
+    validateTimezone(city.timezone, city.countryId).flatMap {
+      case Left(error) => error.elevate[F, Long]
+      case Right(_)    => modifyCity(city).attemptUpdate(city.id).execute
+    }
 
   override def partiallyUpdateCity(id: Long, patch: CityPatch): F[ApiResult[City]] =
     EitherT(getCity(id)).flatMapF { cityOutput =>
       val city = cityOutput.value
       val patched = City.fromPatch(id, patch, city)
-      modifyCity(patched).attemptUpdate(patched).execute
+      validateTimezone(patched.timezone, patched.countryId).flatMap {
+        case Left(error) => error.elevate[F, City]
+        case Right(_)    => modifyCity(patched).attemptUpdate(patched).execute
+      }
     }.value
 
   override def removeCity(id: Long): F[ApiResult[Unit]] =
     deleteCity(id).attemptDelete(id).execute
+
+  override protected def validateTimezone(timezone: String, countryId: Long): F[ApiResult[Unit]] =
+    EitherT(
+      CountryQueries
+        .selectCountriesBy("id", countryId)
+        .map(_.iso2)
+        .asSingle(countryId)
+    ).leftMap {
+        case EntryNotFound(_) => EntryHasInvalidForeignKey
+        case other            => other
+      }
+      .subflatMap[ApiError, ApiOutput[Unit]] { countryIso2Output =>
+        val countryIso2 = countryIso2Output.value
+        Either
+          .raiseUnless(timezoneMatchesCountry(timezone, countryIso2))(InvalidTimezone(timezone))
+          .map(Got(_))
+      }
+      .value
+      .execute
+
+  private def timezoneMatchesCountry(tz: String, country: String): Boolean =
+    TimeZone.getAvailableIDs(country).contains(tz)
 }
 
 object CityRepository {

--- a/src/main/scala/flightdatabase/repository/CountryRepository.scala
+++ b/src/main/scala/flightdatabase/repository/CountryRepository.scala
@@ -4,13 +4,18 @@ import cats.data.EitherT
 import cats.effect.Concurrent
 import cats.effect.Resource
 import cats.implicits._
+import doobie.Fragment
 import doobie.Put
 import doobie.Transactor
+import doobie.implicits._
 import flightdatabase.domain.ApiResult
+import flightdatabase.domain.InvalidField
 import flightdatabase.domain.country.Country
 import flightdatabase.domain.country.CountryAlgebra
 import flightdatabase.domain.country.CountryCreate
 import flightdatabase.domain.country.CountryPatch
+import flightdatabase.domain.currency.Currency
+import flightdatabase.domain.language.Language
 import flightdatabase.repository.queries.CountryQueries._
 import flightdatabase.utils.implicits._
 
@@ -32,6 +37,36 @@ class CountryRepository[F[_]: Concurrent] private (
 
   override def getCountries[V: Put](field: String, value: V): F[ApiResult[List[Country]]] =
     selectCountriesBy(field, value).asList.execute
+
+  override def getCountriesByLanguage[V: Put](
+    field: String,
+    value: V
+  ): F[ApiResult[List[Country]]] = {
+    def q(idField: String): Fragment =
+      selectCountriesByExternal[Language, V](field, value, Some(idField)).toFragment
+    val allowedFields = Set("id", "name", "iso2", "iso3")
+    if (allowedFields(field)) {
+      {
+        q("main_language_id") ++ fr"UNION" ++
+        q("secondary_language_id") ++ fr"UNION" ++
+        q("tertiary_language_id")
+      }.query[Country].asList.execute
+    } else {
+      InvalidField(field).elevate[F, List[Country]]
+    }
+  }
+
+  override def getCountriesByCurrency[V: Put](
+    field: String,
+    value: V
+  ): F[ApiResult[List[Country]]] = {
+    val allowedFields = Set("id", "name", "iso")
+    if (allowedFields(field)) {
+      selectCountriesByExternal[Currency, V](field, value).asList.execute
+    } else {
+      InvalidField(field).elevate[F, List[Country]]
+    }
+  }
 
   override def createCountry(country: CountryCreate): F[ApiResult[Long]] =
     insertCountry(country).attemptInsert.execute

--- a/src/main/scala/flightdatabase/repository/CountryRepository.scala
+++ b/src/main/scala/flightdatabase/repository/CountryRepository.scala
@@ -36,8 +36,8 @@ class CountryRepository[F[_]: Concurrent] private (
   override def createCountry(country: CountryCreate): F[ApiResult[Long]] =
     insertCountry(country).attemptInsert.execute
 
-  override def updateCountry(country: Country): F[ApiResult[Country]] =
-    modifyCountry(country).attemptUpdate(country).execute
+  override def updateCountry(country: Country): F[ApiResult[Long]] =
+    modifyCountry(country).attemptUpdate(country.id).execute
 
   override def partiallyUpdateCountry(
     id: Long,
@@ -45,7 +45,8 @@ class CountryRepository[F[_]: Concurrent] private (
   ): F[ApiResult[Country]] =
     EitherT(getCountry(id)).flatMapF { countryOutput =>
       val country = countryOutput.value
-      updateCountry(Country.fromPatch(id, patch, country))
+      val patched = Country.fromPatch(id, patch, country)
+      modifyCountry(patched).attemptUpdate(patched).execute
     }.value
 
   override def removeCountry(id: Long): F[ApiResult[Unit]] =

--- a/src/main/scala/flightdatabase/repository/FleetAirplaneRepository.scala
+++ b/src/main/scala/flightdatabase/repository/FleetAirplaneRepository.scala
@@ -56,8 +56,8 @@ class FleetAirplaneRepository[F[_]: Concurrent] private (
 
   override def updateFleetAirplane(
     fleetAirplane: FleetAirplane
-  ): F[ApiResult[FleetAirplane]] =
-    modifyFleetAirplane(fleetAirplane).attemptUpdate(fleetAirplane).execute
+  ): F[ApiResult[Long]] =
+    modifyFleetAirplane(fleetAirplane).attemptUpdate(fleetAirplane.id).execute
 
   override def partiallyUpdateFleetAirplane(
     id: Long,
@@ -65,7 +65,8 @@ class FleetAirplaneRepository[F[_]: Concurrent] private (
   ): F[ApiResult[FleetAirplane]] =
     EitherT(getFleetAirplane(id)).flatMapF { fleetAirplaneOutput =>
       val fleetAirplane = fleetAirplaneOutput.value
-      updateFleetAirplane(FleetAirplane.fromPatch(id, patch, fleetAirplane))
+      val patched = FleetAirplane.fromPatch(id, patch, fleetAirplane)
+      modifyFleetAirplane(patched).attemptUpdate(patched).execute
     }.value
 
   override def removeFleetAirplane(id: Long): F[ApiResult[Unit]] =

--- a/src/main/scala/flightdatabase/repository/FleetRouteRepository.scala
+++ b/src/main/scala/flightdatabase/repository/FleetRouteRepository.scala
@@ -60,8 +60,8 @@ class FleetRouteRepository[F[_]: Concurrent] private (
   override def createFleetRoute(fleetRoute: FleetRouteCreate): F[ApiResult[Long]] =
     insertFleetRoute(fleetRoute).attemptInsert.execute
 
-  override def updateFleetRoute(fleetRoute: FleetRoute): F[ApiResult[FleetRoute]] =
-    modifyFleetRoute(fleetRoute).attemptUpdate(fleetRoute).execute
+  override def updateFleetRoute(fleetRoute: FleetRoute): F[ApiResult[Long]] =
+    modifyFleetRoute(fleetRoute).attemptUpdate(fleetRoute.id).execute
 
   override def partiallyUpdateFleetRoute(
     id: Long,
@@ -69,7 +69,8 @@ class FleetRouteRepository[F[_]: Concurrent] private (
   ): F[ApiResult[FleetRoute]] =
     EitherT(getFleetRoute(id)).flatMapF { fleetRouteOutput =>
       val fleetRoute = fleetRouteOutput.value
-      updateFleetRoute(FleetRoute.fromPatch(id, patch, fleetRoute))
+      val patched = FleetRoute.fromPatch(id, patch, fleetRoute)
+      modifyFleetRoute(patched).attemptUpdate(patched).execute
     }.value
 
   override def removeFleetRoute(id: Long): F[ApiResult[Unit]] =

--- a/src/main/scala/flightdatabase/repository/LanguageRepository.scala
+++ b/src/main/scala/flightdatabase/repository/LanguageRepository.scala
@@ -40,13 +40,14 @@ class LanguageRepository[F[_]: Concurrent] private (
   override def createLanguage(language: LanguageCreate): F[ApiResult[Long]] =
     insertLanguage(language).attemptInsert.execute
 
-  override def updateLanguage(language: Language): F[ApiResult[Language]] =
-    modifyLanguage(language).attemptUpdate(language).execute
+  override def updateLanguage(language: Language): F[ApiResult[Long]] =
+    modifyLanguage(language).attemptUpdate(language.id).execute
 
   override def partiallyUpdateLanguage(id: Long, patch: LanguagePatch): F[ApiResult[Language]] =
     EitherT(getLanguage(id)).flatMapF { languageOutput =>
       val language = languageOutput.value
-      updateLanguage(Language.fromPatch(id, patch, language))
+      val patched = Language.fromPatch(id, patch, language)
+      modifyLanguage(patched).attemptUpdate(patched).execute
     }.value
 
   override def removeLanguage(id: Long): F[ApiResult[Unit]] =

--- a/src/main/scala/flightdatabase/repository/ManufacturerRepository.scala
+++ b/src/main/scala/flightdatabase/repository/ManufacturerRepository.scala
@@ -38,14 +38,14 @@ class ManufacturerRepository[F[_]: Concurrent] private (
     selectManufacturersBy(field, value).asList.execute
 
   override def getManufacturersByCity(city: String): F[ApiResult[List[Manufacturer]]] =
-    selectManufacturersByExternal[City, String]("name", city).asList.execute
+    selectManufacturersByCity[City, String]("name", city).asList.execute
 
   override def getManufacturersByCountry(country: String): F[ApiResult[List[Manufacturer]]] =
     EitherT(
       getFieldList[City, String, Country, String]("name", FieldValue("name", country))
     ).flatMapF {
         _.value
-          .flatTraverse(selectManufacturersByExternal[City, String]("name", _).to[List])
+          .flatTraverse(selectManufacturersByCity[City, String]("name", _).to[List])
           .map(listToApiResult)
       }
       .value

--- a/src/main/scala/flightdatabase/repository/ManufacturerRepository.scala
+++ b/src/main/scala/flightdatabase/repository/ManufacturerRepository.scala
@@ -54,8 +54,8 @@ class ManufacturerRepository[F[_]: Concurrent] private (
   override def createManufacturer(manufacturer: ManufacturerCreate): F[ApiResult[Long]] =
     insertManufacturer(manufacturer).attemptInsert.execute
 
-  override def updateManufacturer(manufacturer: Manufacturer): F[ApiResult[Manufacturer]] =
-    modifyManufacturer(manufacturer).attemptUpdate(manufacturer).execute
+  override def updateManufacturer(manufacturer: Manufacturer): F[ApiResult[Long]] =
+    modifyManufacturer(manufacturer).attemptUpdate(manufacturer.id).execute
 
   override def partiallyUpdateManufacturer(
     id: Long,
@@ -63,7 +63,8 @@ class ManufacturerRepository[F[_]: Concurrent] private (
   ): F[ApiResult[Manufacturer]] =
     EitherT(getManufacturer(id)).flatMapF { manufacturerOutput =>
       val manufacturer = manufacturerOutput.value
-      updateManufacturer(Manufacturer.fromPatch(id, patch, manufacturer))
+      val patched = Manufacturer.fromPatch(id, patch, manufacturer)
+      modifyManufacturer(patched).attemptUpdate(patched).execute
     }.value
 
   override def removeManufacturer(id: Long): F[ApiResult[Unit]] =

--- a/src/main/scala/flightdatabase/repository/package.scala
+++ b/src/main/scala/flightdatabase/repository/package.scala
@@ -28,7 +28,7 @@ package object repository {
       index <- selectWhereQuery[WT, Long, WV]("id", whereFieldValue.field, whereFieldValue.value).option.attempt
       values <- index match {
         case Right(Some(id)) => selectWhereQuery[ST, SV, Long](selectField, idField, id).asList
-        case Right(None)     => EntryNotFound(whereFieldValue.toString).elevate[ConnectionIO, List[SV]]
+        case Right(None)     => EntryNotFound(whereFieldValue).elevate[ConnectionIO, List[SV]]
         case Left(error)     => UnknownError(error.getMessage).elevate[ConnectionIO, List[SV]]
       }
     } yield values

--- a/src/main/scala/flightdatabase/repository/package.scala
+++ b/src/main/scala/flightdatabase/repository/package.scala
@@ -29,7 +29,7 @@ package object repository {
       values <- index match {
         case Right(Some(id)) => selectWhereQuery[ST, SV, Long](selectField, idField, id).asList
         case Right(None)     => EntryNotFound(whereFieldValue).elevate[ConnectionIO, List[SV]]
-        case Left(error)     => UnknownError(error.getMessage).elevate[ConnectionIO, List[SV]]
+        case Left(error)     => UnknownDbError(error.getMessage).elevate[ConnectionIO, List[SV]]
       }
     } yield values
   }
@@ -43,6 +43,6 @@ package object repository {
     case sqlstate.class23.NOT_NULL_VIOLATION    => EntryNullCheckFailed
     case sqlstate.class23.UNIQUE_VIOLATION      => EntryAlreadyExists
     case sqlstate.class23.FOREIGN_KEY_VIOLATION => EntryHasInvalidForeignKey
-    case _                                      => UnknownError(state.value)
+    case _                                      => UnknownDbError(state.value)
   }
 }

--- a/src/main/scala/flightdatabase/repository/queries/CountryQueries.scala
+++ b/src/main/scala/flightdatabase/repository/queries/CountryQueries.scala
@@ -20,11 +20,13 @@ private[repository] object CountryQueries {
 
   def selectCountriesByExternal[ET: TableBase, EV: Put](
     externalField: String,
-    externalValue: EV
+    externalValue: EV,
+    overrideExternalIdField: Option[String] = None
   ): Query0[Country] = {
     selectAll ++ innerJoinWhereFragment[Country, ET, EV](
       externalField,
-      externalValue
+      externalValue,
+      overrideExternalIdField
     )
   }.query[Country]
 

--- a/src/main/scala/flightdatabase/repository/queries/ManufacturerQueries.scala
+++ b/src/main/scala/flightdatabase/repository/queries/ManufacturerQueries.scala
@@ -18,20 +18,21 @@ private[repository] object ManufacturerQueries {
   def selectManufacturersBy[V: Put](field: String, value: V): Query0[Manufacturer] =
     (selectAll ++ whereFragment(s"manufacturer.$field", value)).query[Manufacturer]
 
-  def selectManufacturersByExternal[ET: TableBase, EV: Put](
+  def selectManufacturersByCity[ET: TableBase, EV: Put](
     externalField: String,
     externalValue: EV
   ): Query0[Manufacturer] = {
     selectAll ++ innerJoinWhereFragment[Manufacturer, ET, EV](
       externalField,
-      externalValue
+      externalValue,
+      Some("city_based_in")
     )
   }.query[Manufacturer]
 
   def insertManufacturer(model: ManufacturerCreate): Update0 =
     sql"""
          | INSERT INTO manufacturer (name, city_based_in) 
-         | VALUES (${model.name}, ${model.basedIn})
+         | VALUES (${model.name}, ${model.cityBasedIn})
        """.stripMargin.update
 
   def modifyManufacturer(model: Manufacturer): Update0 =
@@ -39,7 +40,7 @@ private[repository] object ManufacturerQueries {
          | UPDATE manufacturer
          | SET
          |  name = ${model.name},
-         |  city_based_in = ${model.basedIn}
+         |  city_based_in = ${model.cityBasedIn}
          | WHERE id = ${model.id}
        """.stripMargin.update
 

--- a/src/main/scala/flightdatabase/todos.md
+++ b/src/main/scala/flightdatabase/todos.md
@@ -1,6 +1,7 @@
 TODO list
 ----------
 
+- ~~Perhaps consider using `fly4s` instead of the original Java implementation of `Flyway`.~~ Not needed for now.
 - ~~Rename `services` to `endpoints` and accordingly all file names, e.g., `AirplaneService` to `AirplaneEndpoint`.~~ DONE!
 - ~~Refactor the project structure to introduce a domain package that will contain separate sub-packages for each database object. Each of these sub-packages will include two files:~~ DONE!
 	- ~~A {dbObject}Model.scala file that defines the case class for the database object.~~ DONE!
@@ -13,9 +14,14 @@ TODO list
 - ~~Upgrade all dependencies, especially doobie and http4s since they have some major changes.~~ DONE!
 - ~~Add logging for doobie queries.~~ DONE!
 - ~~Write tests for all generic doobie queries.~~ DONE!
-- Implement all doobie queries.
-- Write tests for all specific doobie queries.
-- Implement all endpoints using algebras.
-- Write tests for all endpoints and algebras.
+- ~~Implement all doobie queries.~~ DONE for now... more will be added as needed.
+- ~~Write tests for all specific doobie queries.~~ DONE!
+- ~~Implement all endpoints using algebras.~~ DONE!
+- Write integration tests for all algebras.
+- Write unit tests for all endpoints.
+- Update the `README.md` to reflect the changes in the project structure and the new features.
 - Expand API endpoint list to include more complex operations as indicated in `endpoints.md`.
-- Perhaps consider using `fly4s` instead of the original Java implementation of `Flyway`.
+- Move domain to a separate module and rename `src` to `core`. 
+- Upgrade to sbt 1.9.9 and restructure build.sbt to account for multiple modules.
+- Add a `Dockerfile` and `docker-compose.yml` to run the application in a container.
+- Start working on the frontend using ScalaJS!

--- a/src/main/scala/flightdatabase/todos.md
+++ b/src/main/scala/flightdatabase/todos.md
@@ -18,6 +18,8 @@ TODO list
 - ~~Write tests for all specific doobie queries.~~ DONE!
 - ~~Implement all endpoints using algebras.~~ DONE!
 - Write integration tests for all algebras.
+- All `endpoints` should return URI of the created resource in the `Location` header.
+- Add a URI to all foreign key fields in the response (maybe use something similar to `TableBase`).
 - Write unit tests for all endpoints.
 - Update the `README.md` to reflect the changes in the project structure and the new features.
 - Expand API endpoint list to include more complex operations as indicated in `endpoints.md`.

--- a/src/main/scala/flightdatabase/utils/implicits/RichQuery.scala
+++ b/src/main/scala/flightdatabase/utils/implicits/RichQuery.scala
@@ -6,7 +6,7 @@ import doobie.Query0
 import doobie.implicits._
 import flightdatabase.domain.ApiResult
 import flightdatabase.domain.EntryNotFound
-import flightdatabase.domain.UnknownError
+import flightdatabase.domain.UnknownDbError
 import flightdatabase.domain.listToApiResult
 import flightdatabase.domain.toApiResult
 import flightdatabase.repository.sqlStateToApiError
@@ -24,7 +24,7 @@ class RichQuery[A](private val q: Query0[A]) extends AnyVal {
     q.option.attempt.map {
       case Right(Some(a)) => toApiResult(a)
       case Right(None)    => EntryNotFound(entry).asResult[A]
-      case Left(error)    => UnknownError(error.getMessage).asResult[A]
+      case Left(error)    => UnknownDbError(error.getMessage).asResult[A]
     }
 
   def asStream: Stream[ConnectionIO, ApiResult[A]] = q.stream.map(toApiResult)

--- a/src/main/scala/flightdatabase/utils/implicits/RichQuery.scala
+++ b/src/main/scala/flightdatabase/utils/implicits/RichQuery.scala
@@ -23,7 +23,7 @@ class RichQuery[A](private val q: Query0[A]) extends AnyVal {
   def asSingle[E](entry: E): ConnectionIO[ApiResult[A]] =
     q.option.attempt.map {
       case Right(Some(a)) => toApiResult(a)
-      case Right(None)    => EntryNotFound(entry.toString).asResult[A]
+      case Right(None)    => EntryNotFound(entry).asResult[A]
       case Left(error)    => UnknownError(error.getMessage).asResult[A]
     }
 


### PR DESCRIPTION
Two repositories have been excluded:
- FleetRepository
- FleetRouteRepository

This is due to a necessary restructuring of `Fleet` to account for multiple hub airports per fleet. And also, `fleet` will be renamed to `airline`.